### PR TITLE
Replace rustacuda by cudarc

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ impl NvDecoder {
 ```
 
 1. `NvDecoder` can be obtained with `NvDecoder::builder().x().y().z().build()`, provided a
-   `rustacuda` `Context` has been created.
+   `cudarc` `CudaContext` has been created.
 1. The decoder is then fed with `NvDecoder::decode(data, ...)`, which makes it parse and process
    the `data`.
 1. If decoding is successful the results can be queried with methods like `NvDecoder::get_width()`,

--- a/nv-video-codec/Cargo.toml
+++ b/nv-video-codec/Cargo.toml
@@ -14,9 +14,7 @@ bitflags = "1.2"
 gl = "0.14"
 nv-video-codec-sys = { path = "../nv-video-codec-sys" }
 parking_lot = "0.11"
-rustacuda = "0.1"
-rustacuda_core = "0.1"
-rustacuda_derive = "0.1"
+cudarc = { version = "0.19", features = ["cuda-version-from-build-system"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/nv-video-codec/src/decoder/builder.rs
+++ b/nv-video-codec/src/decoder/builder.rs
@@ -1,12 +1,12 @@
-use rustacuda::context::Context;
-
 use super::{
     types::{Codec, Dim, Rect},
     NvDecoder, NvDecoderError,
 };
+use cudarc::driver::CudaContext;
+use std::sync::Arc;
 
 pub struct NvDecoderBuilder {
-    pub(super) context: Context,
+    pub(super) context: Arc<CudaContext>,
     pub(super) use_device_frame: bool,
     pub(super) codec: Codec,
     pub(super) low_latency: bool,
@@ -35,7 +35,7 @@ impl NvDecoderBuilder {
 
     builder_field_setter!(clock_rate: u32);
 
-    pub fn new(context: Context, codec: Codec) -> Self {
+    pub fn new(context: Arc<CudaContext>, codec: Codec) -> Self {
         Self {
             context,
             use_device_frame: false,

--- a/nv-video-codec/src/decoder/mod.rs
+++ b/nv-video-codec/src/decoder/mod.rs
@@ -6,6 +6,7 @@ pub mod frame;
 pub mod frame_info;
 pub mod nvdecoder;
 pub mod types;
+mod util;
 pub mod videoformat;
 
 pub use builder::*;

--- a/nv-video-codec/src/decoder/nvdecoder.rs
+++ b/nv-video-codec/src/decoder/nvdecoder.rs
@@ -4,7 +4,10 @@ use super::{
 };
 use crate::{
     common::cuda_result::IntoCudaResult,
-    decoder::{DecodingOutput, FrameInfo, NvDecoderBuilder},
+    decoder::{
+        util::{pop_context, push_context},
+        DecodingOutput, FrameInfo, NvDecoderBuilder,
+    },
 };
 use ffi::{
     cuMemAllocPitch_v2, cuMemAlloc_v2, cuMemFree_v2, cuMemcpy2DAsync_v2, cuStreamSynchronize,
@@ -20,7 +23,6 @@ use ffi::{
 };
 use nv_video_codec_sys as ffi;
 use parking_lot::Mutex;
-use rustacuda::context::{Context, ContextHandle, ContextStack};
 use std::{
     collections::VecDeque,
     convert::TryInto,
@@ -30,11 +32,12 @@ use std::{
 };
 
 use super::{DecoderPacketFlags, Frame, NvDecoderError};
+use cudarc::driver::CudaContext;
 
 pub struct NvDecoder<'a> {
     parser: CUvideoparser,
     decoder: CUvideodecoder,
-    context: Context,
+    context: Arc<CudaContext>,
     use_device_frame: bool,
     codec: Codec,
     chroma_format: ChromaFormat,
@@ -107,18 +110,18 @@ unsafe extern "C" fn handle_operating_point_proc(
     (decoder as *mut NvDecoder).as_mut().unwrap().handle_operating_point(op_info)
 }
 
-fn do_within_context<F, T>(context: &Context, mut func: F)
+fn do_within_context<F, T>(context: &CudaContext, mut func: F)
 where
     F: FnMut() -> T,
     T: IntoCudaResult<()>,
 {
-    ContextStack::push(context).unwrap();
+    push_context(context).unwrap();
     func().into_cuda_result().expect("Cuda NVDEC api call failure");
-    ContextStack::pop().unwrap();
+    pop_context().unwrap();
 }
 
 impl<'a> NvDecoder<'a> {
-    pub fn builder(context: Context, codec: Codec) -> NvDecoderBuilder {
+    pub fn builder(context: Arc<CudaContext>, codec: Codec) -> NvDecoderBuilder {
         NvDecoderBuilder::new(context, codec)
     }
 
@@ -361,7 +364,7 @@ impl<'a> NvDecoder<'a> {
 
         // TODO(efyang) : figure out how to make cuvid do_ctxpush_cuvidfunc lifetimes work
         // here with this
-        ContextStack::push(&self.context).unwrap();
+        push_context(&self.context).unwrap();
         unsafe {
             // NOTE: this call takes about 1.6ms (about half the total time of this func)
             // TODO(efyang): optimization in final implementation
@@ -532,7 +535,7 @@ impl<'a> NvDecoder<'a> {
             cuStreamSynchronize(self.stream).into_cuda_result().unwrap();
         }
 
-        ContextStack::pop().unwrap();
+        pop_context().unwrap();
         // timestamp already set earlier
 
         // NOTE: this call takes negligible time (about 2us)
@@ -575,7 +578,7 @@ impl<'a> NvDecoder<'a> {
     pub(super) fn new(builder: NvDecoderBuilder) -> Result<Box<Self>, NvDecoderError> {
         let ctx_lock = unsafe {
             let mut ctx_lock = std::ptr::null_mut();
-            cuvidCtxLockCreate(&mut ctx_lock, builder.context.get_inner() as *mut ffi::CUctx_st)
+            cuvidCtxLockCreate(&mut ctx_lock, builder.context.cu_ctx() as *mut ffi::CUctx_st)
                 .into_cuda_result()?;
             ctx_lock
         };
@@ -734,7 +737,7 @@ impl<'a> Drop for NvDecoder<'a> {
             }
         }
 
-        ContextStack::pop().unwrap();
+        pop_context().unwrap();
         unsafe {
             let err = cuvidCtxLockDestroy(self.ctx_lock);
             err.into_cuda_result().expect("Failure on nvdecoder ctx lock destroy");

--- a/nv-video-codec/src/decoder/nvdecoder.rs
+++ b/nv-video-codec/src/decoder/nvdecoder.rs
@@ -4,10 +4,7 @@ use super::{
 };
 use crate::{
     common::cuda_result::IntoCudaResult,
-    decoder::{
-        util::{pop_context, push_context},
-        DecodingOutput, FrameInfo, NvDecoderBuilder,
-    },
+    decoder::{util::ContextStack, DecodingOutput, FrameInfo, NvDecoderBuilder},
 };
 use ffi::{
     cuMemAllocPitch_v2, cuMemAlloc_v2, cuMemFree_v2, cuMemcpy2DAsync_v2, cuStreamSynchronize,
@@ -115,9 +112,9 @@ where
     F: FnMut() -> T,
     T: IntoCudaResult<()>,
 {
-    push_context(context).unwrap();
+    ContextStack::push(context).unwrap();
     func().into_cuda_result().expect("Cuda NVDEC api call failure");
-    pop_context().unwrap();
+    ContextStack::pop().unwrap();
 }
 
 impl<'a> NvDecoder<'a> {
@@ -364,7 +361,7 @@ impl<'a> NvDecoder<'a> {
 
         // TODO(efyang) : figure out how to make cuvid do_ctxpush_cuvidfunc lifetimes work
         // here with this
-        push_context(&self.context).unwrap();
+        ContextStack::push(&self.context).unwrap();
         unsafe {
             // NOTE: this call takes about 1.6ms (about half the total time of this func)
             // TODO(efyang): optimization in final implementation
@@ -535,7 +532,7 @@ impl<'a> NvDecoder<'a> {
             cuStreamSynchronize(self.stream).into_cuda_result().unwrap();
         }
 
-        pop_context().unwrap();
+        ContextStack::pop().unwrap();
         // timestamp already set earlier
 
         // NOTE: this call takes negligible time (about 2us)
@@ -737,7 +734,7 @@ impl<'a> Drop for NvDecoder<'a> {
             }
         }
 
-        pop_context().unwrap();
+        ContextStack::pop().unwrap();
         unsafe {
             let err = cuvidCtxLockDestroy(self.ctx_lock);
             err.into_cuda_result().expect("Failure on nvdecoder ctx lock destroy");

--- a/nv-video-codec/src/decoder/util.rs
+++ b/nv-video-codec/src/decoder/util.rs
@@ -4,15 +4,19 @@ use cudarc::driver::{
 };
 use std::ptr::null_mut;
 
-pub(crate) fn push_context(ctx: &CudaContext) -> Result<(), DriverError> {
-    let cu_ctx = ctx.cu_ctx();
-    let result = unsafe { cuCtxPushCurrent_v2(cu_ctx) };
-    result.result()
-}
+pub(crate) struct ContextStack;
 
-pub(crate) fn pop_context() -> Result<(), DriverError> {
-    let mut cu_ctx: CUcontext = null_mut();
-    let result = unsafe { cuCtxPopCurrent_v2(&raw mut cu_ctx) };
+impl ContextStack {
+    pub(crate) fn push(ctx: &CudaContext) -> Result<(), DriverError> {
+        let cu_ctx = ctx.cu_ctx();
+        let result = unsafe { cuCtxPushCurrent_v2(cu_ctx) };
+        result.result()
+    }
 
-    result.result()
+    pub(crate) fn pop() -> Result<(), DriverError> {
+        let mut cu_ctx: CUcontext = null_mut();
+        let result = unsafe { cuCtxPopCurrent_v2(&raw mut cu_ctx) };
+
+        result.result()
+    }
 }

--- a/nv-video-codec/src/decoder/util.rs
+++ b/nv-video-codec/src/decoder/util.rs
@@ -1,0 +1,18 @@
+use cudarc::driver::{
+    sys::{cuCtxPopCurrent_v2, cuCtxPushCurrent_v2, CUcontext},
+    CudaContext, DriverError,
+};
+use std::ptr::null_mut;
+
+pub(crate) fn push_context(ctx: &CudaContext) -> Result<(), DriverError> {
+    let cu_ctx = ctx.cu_ctx();
+    let result = unsafe { cuCtxPushCurrent_v2(cu_ctx) };
+    result.result()
+}
+
+pub(crate) fn pop_context() -> Result<(), DriverError> {
+    let mut cu_ctx: CUcontext = null_mut();
+    let result = unsafe { cuCtxPopCurrent_v2(&raw mut cu_ctx) };
+
+    result.result()
+}

--- a/nv-video-codec/src/encoder/builder.rs
+++ b/nv-video-codec/src/encoder/builder.rs
@@ -1,5 +1,4 @@
 use super::{BufferFormat, NvEncoderError, NvEncoderGL};
-// use rustacuda::context::Context;
 
 // pub struct NvEncoderCudaBuilder {
 //     context: Context,

--- a/nv-video-codec/src/lib.rs
+++ b/nv-video-codec/src/lib.rs
@@ -5,11 +5,8 @@ extern crate thiserror;
 #[macro_use]
 extern crate bitflags;
 
+extern crate cudarc;
 extern crate gl;
-extern crate rustacuda;
-
-extern crate rustacuda_core;
-extern crate rustacuda_derive;
 
 extern crate parking_lot;
 

--- a/nv-video-codec/tests/decoder.rs
+++ b/nv-video-codec/tests/decoder.rs
@@ -8,20 +8,15 @@ mod utils;
 
 use anyhow::Result;
 use nv_video_codec::decoder::{DecoderPacketFlags, NvDecoder};
-use rustacuda::{
-    context::{Context, ContextFlags},
-    device::Device,
-};
 use simple_logger::SimpleLogger;
 
+use cudarc::driver::CudaContext;
+use std::sync::Arc;
 #[cfg(feature = "torture")]
 use std::time::Duration;
 
-fn init_cuda_ctx() -> Result<Context> {
-    rustacuda::init(rustacuda::CudaFlags::empty())?;
-    let device = Device::get_device(0)?;
-    let context =
-        Context::create_and_push(ContextFlags::MAP_HOST | ContextFlags::SCHED_AUTO, device)?;
+fn init_cuda_ctx() -> Result<Arc<CudaContext>> {
+    let context = CudaContext::new(0)?;
     Ok(context)
 }
 


### PR DESCRIPTION
Fixes #47 

I hit a small snag with rustacuda, so I went ahead and fixed this issue. It seems to work, at least locally.

The only non-trivial parts are the custom push/pop context impls. I'm not sure why the calls are even needed (perhaps some insane multi-context multi-threaded juggling). They seem rarely used, which is likely why `cudarc` doesn't provide safe wrappers in the first place. But for now I kept them.