### PR TITLE
Simpler encoder init

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The main interface is provided by `NvEncoder<ResourceManager>`.
 
 ```rust
 impl<ResourceManager> NvEncoder<ResourceManager> {
-    pub fn create_encoder(&mut self, encoder_params: &NV_ENC_INITIALIZE_PARAMS) -> NvEncoderResult<()>;
+    pub fn create_encoder(&mut self, encoder_params: &NvEncoderParams) -> NvEncoderResult<()>;
     pub fn destroy_encoder(&mut self) -> NvEncoderResult<()>;
     pub fn get_next_input_frame(&mut self) -> &mut NvEncInputFrame;
     pub fn get_next_input_resource(&mut self) -> &mut ResourceManager::InputResource;
@@ -31,12 +31,6 @@ impl<ResourceManager> NvEncoder<ResourceManager> {
         pic_flags: EncodePicFlags,
     ) -> NvEncoderResult<()>;
     pub fn end_encode(&mut self, packet: &mut Vec<&[u8]>) -> NvEncoderResult<()>;
-    pub fn create_default_encoder_params(
-        &mut self,
-        codec_guid: GUID,
-        preset_guid: GUID,
-        tuning_info: EncodeTuningInfo,
-    ) -> NvEncoderResult<NV_ENC_INITIALIZE_PARAMS>;
 }
 ```
 

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -107,14 +107,14 @@ where
             return Err(NvEncError::NoEncodeDevice.into());
         }
 
-        let (mut encoder_params, mut encode_config) = self
-            .create_default_encoder_params_and_config(
+        let (mut initialize_params, mut encode_config) = self
+            .create_default_initialize_params_and_config(
                 params.codec,
                 params.preset,
                 params.tuning_info,
             )?;
 
-        encoder_params.frameRateNum = params.frame_rate;
+        initialize_params.frameRateNum = params.frame_rate;
         params.apply_to_encode_config(self.get_frame_size()?, &mut encode_config);
 
         if self.width == 0 || self.height == 0 {
@@ -159,21 +159,21 @@ where
             },
         }
 
-        encoder_params.encodeConfig = &raw mut encode_config;
+        initialize_params.encodeConfig = &raw mut encode_config;
 
         unsafe {
             self.nv_encode_api_function_list.nvEncInitializeEncoder.unwrap()(
                 self.encoder_handle as *mut _,
-                &raw mut encoder_params,
+                &raw mut initialize_params,
             )
             .into_nvenc_result()?;
         }
 
         self.encoder_initialized = true;
-        self.width = encoder_params.encodeWidth;
-        self.height = encoder_params.encodeHeight;
-        self.max_encode_width = encoder_params.maxEncodeWidth;
-        self.max_encode_height = encoder_params.maxEncodeHeight;
+        self.width = initialize_params.encodeWidth;
+        self.height = initialize_params.encodeHeight;
+        self.max_encode_width = initialize_params.maxEncodeWidth;
+        self.max_encode_height = initialize_params.maxEncodeHeight;
 
         // TODO(efyang): convert this to a usize
         self.encoder_buffer = encode_config.frameIntervalP
@@ -336,7 +336,7 @@ where
         }
     }
 
-    fn create_default_encoder_params_and_config(
+    fn create_default_initialize_params_and_config(
         &mut self,
         codec: EncodeCodec,
         preset: EncodePreset,

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -11,14 +11,14 @@ use crate::{
     guids::{EncodeCodec, EncodePreset},
 };
 use nv_video_codec_sys::{
-    guids, NvEncodeAPICreateInstance, NvEncodeAPIGetMaxSupportedVersion, _NV_ENC_PIC_STRUCT,
-    _NV_ENC_QP, GUID, NVENCAPI_MAJOR_VERSION, NVENCAPI_MINOR_VERSION, NVENCAPI_VERSION,
-    NVENC_INFINITE_GOPLENGTH, NV_ENCODE_API_FUNCTION_LIST, NV_ENC_BUFFER_USAGE, NV_ENC_CAPS,
-    NV_ENC_CAPS_PARAM, NV_ENC_CONFIG, NV_ENC_CREATE_BITSTREAM_BUFFER, NV_ENC_CREATE_MV_BUFFER,
-    NV_ENC_DEVICE_TYPE, NV_ENC_INITIALIZE_PARAMS, NV_ENC_INPUT_PTR, NV_ENC_INPUT_RESOURCE_TYPE,
-    NV_ENC_LOCK_BITSTREAM, NV_ENC_MAP_INPUT_RESOURCE, NV_ENC_MEONLY_PARAMS,
-    NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS, NV_ENC_OUTPUT_PTR, NV_ENC_PIC_PARAMS,
-    NV_ENC_PRESET_CONFIG, NV_ENC_QP, NV_ENC_REGISTERED_PTR, NV_ENC_REGISTER_RESOURCE,
+    guids, NvEncodeAPICreateInstance, NvEncodeAPIGetMaxSupportedVersion, _NV_ENC_PIC_STRUCT, GUID,
+    NVENCAPI_MAJOR_VERSION, NVENCAPI_MINOR_VERSION, NVENCAPI_VERSION, NVENC_INFINITE_GOPLENGTH,
+    NV_ENCODE_API_FUNCTION_LIST, NV_ENC_BUFFER_USAGE, NV_ENC_CAPS, NV_ENC_CAPS_PARAM,
+    NV_ENC_CONFIG, NV_ENC_CREATE_BITSTREAM_BUFFER, NV_ENC_CREATE_MV_BUFFER, NV_ENC_DEVICE_TYPE,
+    NV_ENC_INITIALIZE_PARAMS, NV_ENC_INPUT_PTR, NV_ENC_INPUT_RESOURCE_TYPE, NV_ENC_LOCK_BITSTREAM,
+    NV_ENC_MAP_INPUT_RESOURCE, NV_ENC_MEONLY_PARAMS, NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS,
+    NV_ENC_OUTPUT_PTR, NV_ENC_PIC_PARAMS, NV_ENC_PRESET_CONFIG, NV_ENC_QP, NV_ENC_REGISTERED_PTR,
+    NV_ENC_REGISTER_RESOURCE,
 };
 use std::marker::PhantomData;
 
@@ -115,95 +115,48 @@ where
             )?;
 
         encoder_params.frameRateNum = params.frame_rate;
-
         params.apply_to_encode_config(self.get_frame_size()?, &mut encode_config);
 
-        encoder_params.encodeConfig = &raw mut encode_config;
-
-        if encoder_params.encodeWidth == 0 || encoder_params.encodeHeight == 0 {
+        if self.width == 0 || self.height == 0 {
             return Err(NvEncError::InvalidParam.into());
         }
 
-        unsafe {
-            if encoder_params.encodeGUID != guids::NV_ENC_CODEC_H264_GUID
-                && encoder_params.encodeGUID != guids::NV_ENC_CODEC_HEVC_GUID
-            {
-                return Err(NvEncError::InvalidParam.into());
-            }
+        match params.codec {
+            EncodeCodec::H264 => {
+                // SAFETY: We checked the codec is H264, so we can access the `hevcConfig` union field.
+                let h264_config = unsafe { &mut encode_config.encodeCodecConfig.h264Config };
 
-            if encoder_params.encodeGUID == guids::NV_ENC_CODEC_H264_GUID
-                && matches!(
+                if matches!(
                     self.buffer_format,
                     BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT
-                )
-            {
-                return Err(NvEncError::InvalidParam.into());
-            }
+                ) {
+                    return Err(NvEncError::InvalidParam.into());
+                }
 
-            if encoder_params.encodeGUID == guids::NV_ENC_CODEC_H264_GUID
-                && matches!(self.buffer_format, BufferFormat::YUV444)
-                && (*encoder_params.encodeConfig).encodeCodecConfig.h264Config.chromaFormatIDC != 3
-            {
-                return Err(NvEncError::InvalidParam.into());
-            }
+                if matches!(self.buffer_format, BufferFormat::YUV444)
+                    && h264_config.chromaFormatIDC != 3
+                {
+                    return Err(NvEncError::InvalidParam.into());
+                }
+            },
+            EncodeCodec::Hevc => {
+                // SAFETY: We checked the codec is HEVC, so we can access the `hevcConfig` union field.
+                let hevc_config = unsafe { &mut encode_config.encodeCodecConfig.hevcConfig };
 
-            if encoder_params.encodeGUID == guids::NV_ENC_CODEC_HEVC_GUID {
                 let yuv10_bit_format = matches!(
                     self.buffer_format,
                     BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT
                 );
-                if yuv10_bit_format
-                    && (*encoder_params.encodeConfig)
-                        .encodeCodecConfig
-                        .hevcConfig
-                        .pixelBitDepthMinus8()
-                        != 2
-                {
+                if yuv10_bit_format && hevc_config.pixelBitDepthMinus8() != 2 {
                     return Err(NvEncError::InvalidParam.into());
                 }
 
                 if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT)
-                    && (*encoder_params.encodeConfig).encodeCodecConfig.hevcConfig.chromaFormatIDC()
-                        != 3
+                    && hevc_config.chromaFormatIDC() != 3
                 {
                     return Err(NvEncError::InvalidParam.into());
                 }
-            }
-        }
-
-        if !encoder_params.encodeConfig.is_null() {
-            // This branch should always be taken, we copy the config to self.
-
-            encode_config = NV_ENC_CONFIG {
-                version: NV_ENC_CONFIG_VER,
-                ..unsafe { *encoder_params.encodeConfig }
-            };
-        } else {
-            // Can this branch ever be taken?
-
-            let mut preset_config = NV_ENC_PRESET_CONFIG {
-                version: NV_ENC_PRESET_CONFIG_VER,
-                presetCfg: NV_ENC_CONFIG { version: NV_ENC_CONFIG_VER, ..CustomDefault::default() },
-                ..Default::default()
-            };
-            if !self.motion_estimation_only {
-                unsafe {
-                    self.nv_encode_api_function_list.nvEncGetEncodePresetConfigEx.unwrap()(
-                        self.encoder_handle as *mut _,
-                        encoder_params.encodeGUID,
-                        encoder_params.presetGUID,
-                        encoder_params.tuningInfo,
-                        &mut preset_config,
-                    )
-                    .into_nvenc_result()?;
-                }
-                encode_config = preset_config.presetCfg;
-            } else {
-                encode_config.version = NV_ENC_CONFIG_VER;
-                encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into();
-                encode_config.rcParams.constQP =
-                    _NV_ENC_QP { qpInterP: 28, qpInterB: 31, qpIntra: 25 };
-            }
+            },
         }
 
         encoder_params.encodeConfig = &raw mut encode_config;

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -4,14 +4,11 @@ use super::{
     NvEncoderError, NvEncoderResult,
 };
 use crate::{
-    encoder::{
-        defaults::CustomDefault, EncodePicFlags, EncodeRateControlMode, EncodeTuningInfo,
-        NvEncoderParams,
-    },
-    guids::{EncodeCodec, EncodePreset},
+    encoder::{defaults::CustomDefault, EncodePicFlags, EncodeRateControlMode, NvEncoderParams},
+    guids::EncodeCodec,
 };
 use nv_video_codec_sys::{
-    guids, NvEncodeAPICreateInstance, NvEncodeAPIGetMaxSupportedVersion, _NV_ENC_PIC_STRUCT, GUID,
+    NvEncodeAPICreateInstance, NvEncodeAPIGetMaxSupportedVersion, _NV_ENC_PIC_STRUCT, GUID,
     NVENCAPI_MAJOR_VERSION, NVENCAPI_MINOR_VERSION, NVENCAPI_VERSION, NVENC_INFINITE_GOPLENGTH,
     NV_ENCODE_API_FUNCTION_LIST, NV_ENC_BUFFER_USAGE, NV_ENC_CAPS, NV_ENC_CAPS_PARAM,
     NV_ENC_CONFIG, NV_ENC_CREATE_BITSTREAM_BUFFER, NV_ENC_CREATE_MV_BUFFER, NV_ENC_DEVICE_TYPE,
@@ -102,62 +99,13 @@ impl<ResourceManager> NvEncoder<ResourceManager>
 where
     ResourceManager: NvEncoderResourceManager + ?Sized,
 {
-    pub fn create_encoder(&mut self, params: &NvEncoderParams) -> NvEncoderResult<()> {
+    pub fn create_encoder(&mut self, params: NvEncoderParams) -> NvEncoderResult<()> {
         if self.encoder_handle.is_null() {
             return Err(NvEncError::NoEncodeDevice.into());
         }
 
-        let (mut initialize_params, mut encode_config) = self
-            .create_default_initialize_params_and_config(
-                params.codec,
-                params.preset,
-                params.tuning_info,
-            )?;
-
-        initialize_params.frameRateNum = params.frame_rate;
-        params.apply_to_encode_config(self.get_frame_size()?, &mut encode_config);
-
-        if self.width == 0 || self.height == 0 {
-            return Err(NvEncError::InvalidParam.into());
-        }
-
-        match params.codec {
-            EncodeCodec::H264 => {
-                // SAFETY: We checked the codec is H264, so we can access the `hevcConfig` union field.
-                let h264_config = unsafe { &mut encode_config.encodeCodecConfig.h264Config };
-
-                if matches!(
-                    self.buffer_format,
-                    BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT
-                ) {
-                    return Err(NvEncError::InvalidParam.into());
-                }
-
-                if matches!(self.buffer_format, BufferFormat::YUV444)
-                    && h264_config.chromaFormatIDC != 3
-                {
-                    return Err(NvEncError::InvalidParam.into());
-                }
-            },
-            EncodeCodec::Hevc => {
-                // SAFETY: We checked the codec is HEVC, so we can access the `hevcConfig` union field.
-                let hevc_config = unsafe { &mut encode_config.encodeCodecConfig.hevcConfig };
-
-                let yuv10_bit_format = matches!(
-                    self.buffer_format,
-                    BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT
-                );
-                if yuv10_bit_format && hevc_config.pixelBitDepthMinus8() != 2 {
-                    return Err(NvEncError::InvalidParam.into());
-                }
-
-                if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT)
-                    && hevc_config.chromaFormatIDC() != 3
-                {
-                    return Err(NvEncError::InvalidParam.into());
-                }
-            },
-        }
+        let (mut initialize_params, mut encode_config) =
+            self.create_initialize_params_and_config(params)?;
 
         initialize_params.encodeConfig = &raw mut encode_config;
 
@@ -170,10 +118,6 @@ where
         }
 
         self.encoder_initialized = true;
-        self.width = initialize_params.encodeWidth;
-        self.height = initialize_params.encodeHeight;
-        self.max_encode_width = initialize_params.maxEncodeWidth;
-        self.max_encode_height = initialize_params.maxEncodeHeight;
 
         // TODO(efyang): convert this to a usize
         self.encoder_buffer = encode_config.frameIntervalP
@@ -336,11 +280,9 @@ where
         }
     }
 
-    fn create_default_initialize_params_and_config(
+    fn create_initialize_params_and_config(
         &mut self,
-        codec: EncodeCodec,
-        preset: EncodePreset,
-        tuning_info: EncodeTuningInfo,
+        params: NvEncoderParams,
     ) -> NvEncoderResult<(NV_ENC_INITIALIZE_PARAMS, NV_ENC_CONFIG)> {
         if self.encoder_handle.is_null() {
             return Err(NvEncError::NoEncodeDevice.into());
@@ -349,8 +291,8 @@ where
         // nvpipe doesn't even use this
         let mut initialize_params = NV_ENC_INITIALIZE_PARAMS {
             version: NV_ENC_INITIALIZE_PARAMS_VER, // TODO(efyang) actual const func for this
-            encodeGUID: codec.as_guid(),
-            presetGUID: preset.as_guid(),
+            encodeGUID: params.codec.as_guid(),
+            presetGUID: params.preset.as_guid(),
             encodeWidth: self.width,
             encodeHeight: self.height,
             darWidth: self.width,
@@ -377,8 +319,8 @@ where
                 .nvEncGetEncodePresetConfig
                 .expect("Invalid nvEncGetEncodePresetConfig ptr")(
                 self.encoder_handle as *mut _,
-                codec.as_guid(),
-                preset.as_guid(),
+                params.codec.as_guid(),
+                params.preset.as_guid(),
                 &mut preset_config,
             )
             .into_nvenc_result()?;
@@ -390,7 +332,7 @@ where
         encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into();
 
         if !self.motion_estimation_only {
-            initialize_params.tuningInfo = tuning_info.into();
+            initialize_params.tuningInfo = params.tuning_info.into();
             let mut preset_config = NV_ENC_PRESET_CONFIG {
                 version: NV_ENC_PRESET_CONFIG_VER,
                 presetCfg: NV_ENC_CONFIG { version: NV_ENC_CONFIG_VER, ..CustomDefault::default() },
@@ -399,9 +341,9 @@ where
             unsafe {
                 self.nv_encode_api_function_list.nvEncGetEncodePresetConfigEx.unwrap()(
                     self.encoder_handle as *mut _,
-                    codec.as_guid(),
-                    preset.as_guid(),
-                    tuning_info.into(),
+                    params.codec.as_guid(),
+                    params.preset.as_guid(),
+                    params.tuning_info.into(),
                     &mut preset_config,
                 )
                 .into_nvenc_result()?;
@@ -414,33 +356,86 @@ where
             encode_config.rcParams.constQP = NV_ENC_QP { qpInterP: 28, qpInterB: 31, qpIntra: 25 };
         }
 
-        if codec.as_guid() == guids::NV_ENC_CODEC_H264_GUID {
-            if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT) {
-                encode_config.encodeCodecConfig.h264Config.chromaFormatIDC = 3;
-            }
-            encode_config.encodeCodecConfig.h264Config.idrPeriod = encode_config.gopLength;
-        } else if codec.as_guid() == guids::NV_ENC_CODEC_HEVC_GUID {
-            // SAFETY: We checked the codec is HEVC, so we can access the `hevcConfig` union field.
-            let hevc_config = unsafe { &mut encode_config.encodeCodecConfig.hevcConfig };
+        match params.codec {
+            EncodeCodec::H264 => {
+                // SAFETY: We checked the codec is H264, so we can access the `h264Config` union field.
+                let h264_config = unsafe { &mut encode_config.encodeCodecConfig.h264Config };
 
-            let bit_depth_minus_8 = if matches!(
-                self.buffer_format,
-                BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT
-            ) {
-                2
-            } else {
-                0
-            };
+                if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT) {
+                    h264_config.chromaFormatIDC = 3;
+                }
+                h264_config.idrPeriod = encode_config.gopLength;
+            },
+            EncodeCodec::Hevc => {
+                // SAFETY: We checked the codec is HEVC, so we can access the `hevcConfig` union field.
+                let hevc_config = unsafe { &mut encode_config.encodeCodecConfig.hevcConfig };
 
-            hevc_config.set_pixelBitDepthMinus8(bit_depth_minus_8);
-            hevc_config.idrPeriod = encode_config.gopLength;
+                let bit_depth_minus_8 = if matches!(
+                    self.buffer_format,
+                    BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT
+                ) {
+                    2
+                } else {
+                    0
+                };
 
-            if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT) {
-                hevc_config.set_chromaFormatIDC(3);
-            }
+                hevc_config.set_pixelBitDepthMinus8(bit_depth_minus_8);
+                hevc_config.idrPeriod = encode_config.gopLength;
+
+                if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT) {
+                    hevc_config.set_chromaFormatIDC(3);
+                }
+            },
         }
 
+        initialize_params.frameRateNum = params.frame_rate;
+        params.apply_to_encode_config(self.get_frame_size()?, &mut encode_config);
+        Self::validate_encode_config(encode_config, params.codec, self.buffer_format)?;
+
         Ok((initialize_params, encode_config))
+    }
+
+    fn validate_encode_config(
+        encode_config: NV_ENC_CONFIG,
+        codec: EncodeCodec,
+        buffer_format: BufferFormat,
+    ) -> NvEncoderResult<()> {
+        match codec {
+            EncodeCodec::H264 => {
+                // SAFETY: We checked the codec is H264, so we can access the `h264Config` union field.
+                let h264_config = unsafe { &encode_config.encodeCodecConfig.h264Config };
+
+                if matches!(buffer_format, BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT)
+                {
+                    return Err(NvEncError::InvalidParam.into());
+                }
+
+                if matches!(buffer_format, BufferFormat::YUV444) && h264_config.chromaFormatIDC != 3
+                {
+                    return Err(NvEncError::InvalidParam.into());
+                }
+            },
+            EncodeCodec::Hevc => {
+                // SAFETY: We checked the codec is HEVC, so we can access the `hevcConfig` union field.
+                let hevc_config = unsafe { &encode_config.encodeCodecConfig.hevcConfig };
+
+                let yuv10_bit_format = matches!(
+                    buffer_format,
+                    BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT
+                );
+                if yuv10_bit_format && hevc_config.pixelBitDepthMinus8() != 2 {
+                    return Err(NvEncError::InvalidParam.into());
+                }
+
+                if matches!(buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT)
+                    && hevc_config.chromaFormatIDC() != 3
+                {
+                    return Err(NvEncError::InvalidParam.into());
+                }
+            },
+        }
+
+        Ok(())
     }
 
     // not gonna implement this for now, not needed
@@ -481,6 +476,10 @@ where
         motion_estimation_only: bool,
         output_in_video_memory: bool,
     ) -> NvEncoderResult<Self> {
+        if width == 0 || height == 0 {
+            return Err(NvEncError::InvalidParam.into());
+        }
+
         let enc_api = Self::load_nv_enc_api()?;
 
         if enc_api.nvEncOpenEncodeSession.is_none() {

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -109,28 +109,17 @@ where
             return Err(NvEncError::NoEncodeDevice.into());
         }
 
-        let mut encoder_params =
-            self.create_default_encoder_params(params.codec, params.preset, params.tuning_info)?;
+        let mut encode_config =
+            NV_ENC_CONFIG { version: NV_ENC_CONFIG_VER, ..CustomDefault::default() };
 
-        encoder_params.frameRateNum = params.frame_rate;
+        let mut encoder_params = self.create_default_encoder_params(
+            params.codec,
+            params.preset,
+            params.tuning_info,
+            &mut encode_config,
+        )?;
 
-        unsafe {
-            (*encoder_params.encodeConfig).rcParams.rateControlMode =
-                params.rate_control.mode.into();
-            (*encoder_params.encodeConfig).rcParams.lowDelayKeyFrameScale =
-                params.rate_control.low_delay_key_frame_scale;
-            (*encoder_params.encodeConfig).rcParams.averageBitRate =
-                params.rate_control.average_bit_rate;
-            (*encoder_params.encodeConfig).rcParams.vbvBufferSize = self.get_frame_size()?;
-            (*encoder_params.encodeConfig).rcParams.vbvInitialDelay = self.get_frame_size()?;
-            (*encoder_params.encodeConfig)
-                .rcParams
-                .set_enableAQ(params.rate_control.enable_aq as u32);
-            (*encoder_params.encodeConfig)
-                .encodeCodecConfig
-                .hevcConfig
-                .set_repeatSPSPPS(params.repeat_spspps as u32);
-        }
+        Self::configure_encoder_params(&mut encoder_params, params, self.get_frame_size()?);
 
         if encoder_params.encodeWidth == 0 || encoder_params.encodeHeight == 0 {
             return Err(NvEncError::InvalidParam.into());
@@ -399,16 +388,11 @@ where
         codec: EncodeCodec,
         preset: EncodePreset,
         tuning_info: EncodeTuningInfo,
+        encode_config: &mut NV_ENC_CONFIG,
     ) -> NvEncoderResult<NV_ENC_INITIALIZE_PARAMS> {
         if self.encoder_handle.is_null() {
             return Err(NvEncError::NoEncodeDevice.into());
         }
-
-        let encode_config =
-            NV_ENC_CONFIG { version: NV_ENC_CONFIG_VER, ..CustomDefault::default() };
-        // NOTE: Leaking to have a stable address to point to in the `encodeConfig` field below.
-        // TODO(mbernat): Wrap these structs so that we can reduce the `unsafe` and pointer usage.
-        let encode_config = Box::leak(Box::new(encode_config));
 
         // nvpipe doesn't even use this
         let mut initialize_params = NV_ENC_INITIALIZE_PARAMS {
@@ -517,6 +501,32 @@ where
         }
 
         Ok(initialize_params)
+    }
+
+    fn configure_encoder_params(
+        encoder_params: &mut NV_ENC_INITIALIZE_PARAMS,
+        params: &NvEncoderParams,
+        frame_size: u32,
+    ) {
+        encoder_params.frameRateNum = params.frame_rate;
+
+        unsafe {
+            (*encoder_params.encodeConfig).rcParams.rateControlMode =
+                params.rate_control.mode.into();
+            (*encoder_params.encodeConfig).rcParams.lowDelayKeyFrameScale =
+                params.rate_control.low_delay_key_frame_scale;
+            (*encoder_params.encodeConfig).rcParams.averageBitRate =
+                params.rate_control.average_bit_rate;
+            (*encoder_params.encodeConfig).rcParams.vbvBufferSize = frame_size;
+            (*encoder_params.encodeConfig).rcParams.vbvInitialDelay = frame_size;
+            (*encoder_params.encodeConfig)
+                .rcParams
+                .set_enableAQ(params.rate_control.enable_aq as u32);
+            (*encoder_params.encodeConfig)
+                .encodeCodecConfig
+                .hevcConfig
+                .set_repeatSPSPPS(params.repeat_spspps as u32);
+        }
     }
 
     fn get_initialize_params(&self) -> NvEncoderResult<NV_ENC_INITIALIZE_PARAMS> {

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -109,17 +109,18 @@ where
             return Err(NvEncError::NoEncodeDevice.into());
         }
 
-        let mut encode_config =
-            NV_ENC_CONFIG { version: NV_ENC_CONFIG_VER, ..CustomDefault::default() };
+        let (mut encoder_params, mut encode_config) = self
+            .create_default_encoder_params_and_config(
+                params.codec,
+                params.preset,
+                params.tuning_info,
+            )?;
 
-        let mut encoder_params = self.create_default_encoder_params(
-            params.codec,
-            params.preset,
-            params.tuning_info,
-            &mut encode_config,
-        )?;
+        encoder_params.frameRateNum = params.frame_rate;
 
-        Self::configure_encoder_params(&mut encoder_params, params, self.get_frame_size()?);
+        params.apply_to_encode_config(self.get_frame_size()?, &mut encode_config);
+
+        encoder_params.encodeConfig = &raw mut encode_config;
 
         if encoder_params.encodeWidth == 0 || encoder_params.encodeHeight == 0 {
             return Err(NvEncError::InvalidParam.into());
@@ -143,7 +144,8 @@ where
 
             if encoder_params.encodeGUID == guids::NV_ENC_CODEC_H264_GUID
                 && matches!(self.buffer_format, BufferFormat::YUV444)
-                && (*encoder_params.encodeConfig).encodeCodecConfig.h264Config.chromaFormatIDC != 3
+                && (*encoder_params.encodeConfig).encodeCodecConfig.h264Config.chromaFormatIDC
+                    != 3
             {
                 return Err(NvEncError::InvalidParam.into());
             }
@@ -164,7 +166,10 @@ where
                 }
 
                 if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT)
-                    && (*encoder_params.encodeConfig).encodeCodecConfig.hevcConfig.chromaFormatIDC()
+                    && (*encoder_params.encodeConfig)
+                        .encodeCodecConfig
+                        .hevcConfig
+                        .chromaFormatIDC()
                         != 3
                 {
                     return Err(NvEncError::InvalidParam.into());
@@ -383,13 +388,12 @@ where
         }
     }
 
-    fn create_default_encoder_params(
+    fn create_default_encoder_params_and_config(
         &mut self,
         codec: EncodeCodec,
         preset: EncodePreset,
         tuning_info: EncodeTuningInfo,
-        encode_config: &mut NV_ENC_CONFIG,
-    ) -> NvEncoderResult<NV_ENC_INITIALIZE_PARAMS> {
+    ) -> NvEncoderResult<(NV_ENC_INITIALIZE_PARAMS, NV_ENC_CONFIG)> {
         if self.encoder_handle.is_null() {
             return Err(NvEncError::NoEncodeDevice.into());
         }
@@ -406,7 +410,6 @@ where
             frameRateNum: 30, // TODO(efyang): possible optimization?
             frameRateDen: 1,
             enablePTD: 1,
-            encodeConfig: &raw mut *encode_config,
             maxEncodeWidth: self.width,
             maxEncodeHeight: self.height,
             ..Default::default()
@@ -420,6 +423,7 @@ where
             presetCfg: NV_ENC_CONFIG { version: NV_ENC_CONFIG_VER, ..CustomDefault::default() },
             ..CustomDefault::default()
         };
+
         unsafe {
             self.nv_encode_api_function_list
                 .nvEncGetEncodePresetConfig
@@ -432,13 +436,10 @@ where
             .into_nvenc_result()?;
         }
 
-        unsafe {
-            *initialize_params.encodeConfig = preset_config.presetCfg;
-            (*initialize_params.encodeConfig).frameIntervalP = 1;
-            (*initialize_params.encodeConfig).gopLength = NVENC_INFINITE_GOPLENGTH;
-            (*initialize_params.encodeConfig).rcParams.rateControlMode =
-                EncodeRateControlMode::ConstantQp.into();
-        }
+        let mut encode_config = preset_config.presetCfg;
+        encode_config.frameIntervalP = 1;
+        encode_config.gopLength = NVENC_INFINITE_GOPLENGTH;
+        encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into();
 
         if !self.motion_estimation_only {
             initialize_params.tuningInfo = tuning_info.into();
@@ -456,77 +457,45 @@ where
                     &mut preset_config,
                 )
                 .into_nvenc_result()?;
-                *initialize_params.encodeConfig = preset_config.presetCfg;
+
+                encode_config = preset_config.presetCfg;
             }
         } else {
+            // TODO(mbernat): Why are we only modifying self here?
+
             self.encode_config.version = NV_ENC_CONFIG_VER;
             self.encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into();
             self.encode_config.rcParams.constQP =
                 NV_ENC_QP { qpInterP: 28, qpInterB: 31, qpIntra: 25 };
         }
 
-        unsafe {
-            if initialize_params.encodeGUID == guids::NV_ENC_CODEC_H264_GUID {
-                if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT) {
-                    (*initialize_params.encodeConfig)
-                        .encodeCodecConfig
-                        .h264Config
-                        .chromaFormatIDC = 3;
-                }
-                (*initialize_params.encodeConfig).encodeCodecConfig.h264Config.idrPeriod =
-                    (*initialize_params.encodeConfig).gopLength;
-            } else if initialize_params.encodeGUID == guids::NV_ENC_CODEC_HEVC_GUID {
-                (*initialize_params.encodeConfig)
-                    .encodeCodecConfig
-                    .hevcConfig
-                    .set_pixelBitDepthMinus8(
-                        if matches!(
-                            self.buffer_format,
-                            BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT
-                        ) {
-                            2
-                        } else {
-                            0
-                        },
-                    );
-                if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT) {
-                    (*initialize_params.encodeConfig)
-                        .encodeCodecConfig
-                        .hevcConfig
-                        .set_chromaFormatIDC(3);
-                }
-                (*initialize_params.encodeConfig).encodeCodecConfig.hevcConfig.idrPeriod =
-                    (*initialize_params.encodeConfig).gopLength;
+        if codec.as_guid() == guids::NV_ENC_CODEC_H264_GUID {
+            if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT) {
+                encode_config.encodeCodecConfig.h264Config.chromaFormatIDC = 3;
+            }
+            encode_config.encodeCodecConfig.h264Config.idrPeriod = encode_config.gopLength;
+        } else if codec.as_guid() == guids::NV_ENC_CODEC_HEVC_GUID {
+            // SAFETY: We checked the codec is HEVC, so we can access the `hevcConfig` union field.
+            let hevc_config = unsafe { &mut encode_config.encodeCodecConfig.hevcConfig };
+
+            let bit_depth_minus_8 = if matches!(
+                self.buffer_format,
+                BufferFormat::YUV420_10BIT | BufferFormat::YUV444_10BIT
+            ) {
+                2
+            } else {
+                0
+            };
+
+            hevc_config.set_pixelBitDepthMinus8(bit_depth_minus_8);
+            hevc_config.idrPeriod = encode_config.gopLength;
+
+            if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT) {
+                hevc_config.set_chromaFormatIDC(3);
             }
         }
 
-        Ok(initialize_params)
-    }
-
-    fn configure_encoder_params(
-        encoder_params: &mut NV_ENC_INITIALIZE_PARAMS,
-        params: &NvEncoderParams,
-        frame_size: u32,
-    ) {
-        encoder_params.frameRateNum = params.frame_rate;
-
-        unsafe {
-            (*encoder_params.encodeConfig).rcParams.rateControlMode =
-                params.rate_control.mode.into();
-            (*encoder_params.encodeConfig).rcParams.lowDelayKeyFrameScale =
-                params.rate_control.low_delay_key_frame_scale;
-            (*encoder_params.encodeConfig).rcParams.averageBitRate =
-                params.rate_control.average_bit_rate;
-            (*encoder_params.encodeConfig).rcParams.vbvBufferSize = frame_size;
-            (*encoder_params.encodeConfig).rcParams.vbvInitialDelay = frame_size;
-            (*encoder_params.encodeConfig)
-                .rcParams
-                .set_enableAQ(params.rate_control.enable_aq as u32);
-            (*encoder_params.encodeConfig)
-                .encodeCodecConfig
-                .hevcConfig
-                .set_repeatSPSPPS(params.repeat_spspps as u32);
-        }
+        Ok((initialize_params, encode_config))
     }
 
     fn get_initialize_params(&self) -> NvEncoderResult<NV_ENC_INITIALIZE_PARAMS> {

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -89,8 +89,6 @@ where
     buffer_format: BufferFormat,
     device: *mut Device, // Originally a void pointer
     device_type: NV_ENC_DEVICE_TYPE,
-    initialize_params: NV_ENC_INITIALIZE_PARAMS,
-    encode_config: NV_ENC_CONFIG,
     encoder_initialized: bool,
     extra_output_delay: u32,
     bitstream_output_buffer: Vec<NV_ENC_OUTPUT_PTR>,
@@ -144,8 +142,7 @@ where
 
             if encoder_params.encodeGUID == guids::NV_ENC_CODEC_H264_GUID
                 && matches!(self.buffer_format, BufferFormat::YUV444)
-                && (*encoder_params.encodeConfig).encodeCodecConfig.h264Config.chromaFormatIDC
-                    != 3
+                && (*encoder_params.encodeConfig).encodeCodecConfig.h264Config.chromaFormatIDC != 3
             {
                 return Err(NvEncError::InvalidParam.into());
             }
@@ -166,10 +163,7 @@ where
                 }
 
                 if matches!(self.buffer_format, BufferFormat::YUV444 | BufferFormat::YUV444_10BIT)
-                    && (*encoder_params.encodeConfig)
-                        .encodeCodecConfig
-                        .hevcConfig
-                        .chromaFormatIDC()
+                    && (*encoder_params.encodeConfig).encodeCodecConfig.hevcConfig.chromaFormatIDC()
                         != 3
                 {
                     return Err(NvEncError::InvalidParam.into());
@@ -177,15 +171,16 @@ where
             }
         }
 
-        self.initialize_params =
-            NV_ENC_INITIALIZE_PARAMS { version: NV_ENC_INITIALIZE_PARAMS_VER, ..encoder_params };
-
         if !encoder_params.encodeConfig.is_null() {
-            self.encode_config = NV_ENC_CONFIG {
+            // This branch should always be taken, we copy the config to self.
+
+            encode_config = NV_ENC_CONFIG {
                 version: NV_ENC_CONFIG_VER,
                 ..unsafe { *encoder_params.encodeConfig }
             };
         } else {
+            // Can this branch ever be taken?
+
             let mut preset_config = NV_ENC_PRESET_CONFIG {
                 version: NV_ENC_PRESET_CONFIG_VER,
                 presetCfg: NV_ENC_CONFIG { version: NV_ENC_CONFIG_VER, ..CustomDefault::default() },
@@ -202,34 +197,34 @@ where
                     )
                     .into_nvenc_result()?;
                 }
-                self.encode_config = preset_config.presetCfg;
+                encode_config = preset_config.presetCfg;
             } else {
-                self.encode_config.version = NV_ENC_CONFIG_VER;
-                self.encode_config.rcParams.rateControlMode =
-                    EncodeRateControlMode::ConstantQp.into();
-                self.encode_config.rcParams.constQP =
+                encode_config.version = NV_ENC_CONFIG_VER;
+                encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into();
+                encode_config.rcParams.constQP =
                     _NV_ENC_QP { qpInterP: 28, qpInterB: 31, qpIntra: 25 };
             }
         }
-        self.initialize_params.encodeConfig = &mut self.encode_config;
+
+        encoder_params.encodeConfig = &raw mut encode_config;
 
         unsafe {
             self.nv_encode_api_function_list.nvEncInitializeEncoder.unwrap()(
                 self.encoder_handle as *mut _,
-                &mut self.initialize_params,
+                &raw mut encoder_params,
             )
             .into_nvenc_result()?;
         }
 
         self.encoder_initialized = true;
-        self.width = self.initialize_params.encodeWidth;
-        self.height = self.initialize_params.encodeHeight;
-        self.max_encode_width = self.initialize_params.maxEncodeWidth;
-        self.max_encode_height = self.initialize_params.maxEncodeHeight;
+        self.width = encoder_params.encodeWidth;
+        self.height = encoder_params.encodeHeight;
+        self.max_encode_width = encoder_params.maxEncodeWidth;
+        self.max_encode_height = encoder_params.maxEncodeHeight;
 
         // TODO(efyang): convert this to a usize
-        self.encoder_buffer = self.encode_config.frameIntervalP
-            + self.encode_config.rcParams.lookaheadDepth as i32
+        self.encoder_buffer = encode_config.frameIntervalP
+            + encode_config.rcParams.lookaheadDepth as i32
             + self.extra_output_delay as i32;
         self.output_delay = self.encoder_buffer - 1;
         self.mapped_input_buffers.resize(self.encoder_buffer as usize, std::ptr::null_mut());
@@ -461,12 +456,9 @@ where
                 encode_config = preset_config.presetCfg;
             }
         } else {
-            // TODO(mbernat): Why are we only modifying self here?
-
-            self.encode_config.version = NV_ENC_CONFIG_VER;
-            self.encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into();
-            self.encode_config.rcParams.constQP =
-                NV_ENC_QP { qpInterP: 28, qpInterB: 31, qpIntra: 25 };
+            encode_config.version = NV_ENC_CONFIG_VER;
+            encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into();
+            encode_config.rcParams.constQP = NV_ENC_QP { qpInterP: 28, qpInterB: 31, qpIntra: 25 };
         }
 
         if codec.as_guid() == guids::NV_ENC_CODEC_H264_GUID {
@@ -496,13 +488,6 @@ where
         }
 
         Ok((initialize_params, encode_config))
-    }
-
-    fn get_initialize_params(&self) -> NvEncoderResult<NV_ENC_INITIALIZE_PARAMS> {
-        if self.initialize_params.encodeConfig.is_null() {
-            return Err(NvEncError::InvalidPointer.into());
-        }
-        Ok(self.initialize_params)
     }
 
     // not gonna implement this for now, not needed
@@ -589,8 +574,6 @@ where
             buffer_format,
             device,
             device_type,
-            initialize_params: NV_ENC_INITIALIZE_PARAMS::default(),
-            encode_config: CustomDefault::default(),
             encoder_initialized: false,
             extra_output_delay,
             bitstream_output_buffer: Vec::new(),

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -4,7 +4,10 @@ use super::{
     NvEncoderError, NvEncoderResult,
 };
 use crate::{
-    encoder::{defaults::CustomDefault, EncodePicFlags, EncodeRateControlMode, EncodeTuningInfo},
+    encoder::{
+        defaults::CustomDefault, EncodePicFlags, EncodeRateControlMode, EncodeTuningInfo,
+        NvEncoderParams,
+    },
     guids::{EncodeCodec, EncodePreset},
 };
 use nv_video_codec_sys::{
@@ -101,12 +104,32 @@ impl<ResourceManager> NvEncoder<ResourceManager>
 where
     ResourceManager: NvEncoderResourceManager + ?Sized,
 {
-    pub fn create_encoder(
-        &mut self,
-        encoder_params: &NV_ENC_INITIALIZE_PARAMS,
-    ) -> NvEncoderResult<()> {
+    pub fn create_encoder(&mut self, params: &NvEncoderParams) -> NvEncoderResult<()> {
         if self.encoder_handle.is_null() {
             return Err(NvEncError::NoEncodeDevice.into());
+        }
+
+        let mut encoder_params =
+            self.create_default_encoder_params(params.codec, params.preset, params.tuning_info)?;
+
+        encoder_params.frameRateNum = params.frame_rate;
+
+        unsafe {
+            (*encoder_params.encodeConfig).rcParams.rateControlMode =
+                params.rate_control.mode.into();
+            (*encoder_params.encodeConfig).rcParams.lowDelayKeyFrameScale =
+                params.rate_control.low_delay_key_frame_scale;
+            (*encoder_params.encodeConfig).rcParams.averageBitRate =
+                params.rate_control.average_bit_rate;
+            (*encoder_params.encodeConfig).rcParams.vbvBufferSize = self.get_frame_size()?;
+            (*encoder_params.encodeConfig).rcParams.vbvInitialDelay = self.get_frame_size()?;
+            (*encoder_params.encodeConfig)
+                .rcParams
+                .set_enableAQ(params.rate_control.enable_aq as u32);
+            (*encoder_params.encodeConfig)
+                .encodeCodecConfig
+                .hevcConfig
+                .set_repeatSPSPPS(params.repeat_spspps as u32);
         }
 
         if encoder_params.encodeWidth == 0 || encoder_params.encodeHeight == 0 {
@@ -161,7 +184,7 @@ where
         }
 
         self.initialize_params =
-            NV_ENC_INITIALIZE_PARAMS { version: NV_ENC_INITIALIZE_PARAMS_VER, ..*encoder_params };
+            NV_ENC_INITIALIZE_PARAMS { version: NV_ENC_INITIALIZE_PARAMS_VER, ..encoder_params };
 
         if !encoder_params.encodeConfig.is_null() {
             self.encode_config = NV_ENC_CONFIG {
@@ -371,7 +394,7 @@ where
         }
     }
 
-    pub fn create_default_encoder_params(
+    fn create_default_encoder_params(
         &mut self,
         codec: EncodeCodec,
         preset: EncodePreset,

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -2,7 +2,7 @@ use super::{NvEncError, NvEncoderError};
 use crate::guids::{EncodeCodec, EncodePreset};
 use ffi::_NV_ENC_BUFFER_FORMAT;
 use nv_video_codec_sys::{
-    self as ffi, NV_ENC_PARAMS_RC_MODE, NV_ENC_PIC_FLAGS, NV_ENC_TUNING_INFO,
+    self as ffi, NV_ENC_CONFIG, NV_ENC_PARAMS_RC_MODE, NV_ENC_PIC_FLAGS, NV_ENC_TUNING_INFO,
 };
 
 ffi_enum! {
@@ -164,4 +164,38 @@ pub struct NvEncoderParams {
     pub frame_rate: u32,
     pub repeat_spspps: bool,
     pub rate_control: EncodeRateControl,
+}
+
+impl NvEncoderParams {
+    pub(crate) fn apply_to_encode_config(
+        &self,
+        frame_size: u32,
+        encode_config: &mut NV_ENC_CONFIG,
+    ) {
+        encode_config.rcParams.rateControlMode = self.rate_control.mode.into();
+        encode_config.rcParams.lowDelayKeyFrameScale = self.rate_control.low_delay_key_frame_scale;
+        encode_config.rcParams.averageBitRate = self.rate_control.average_bit_rate;
+        encode_config.rcParams.vbvBufferSize = frame_size;
+        encode_config.rcParams.vbvInitialDelay = frame_size;
+        encode_config.rcParams.set_enableAQ(self.rate_control.enable_aq as u32);
+
+        match self.codec {
+            EncodeCodec::H264 =>
+            // SAFETY: We checked the codec is H264, so we can access the union field.
+            unsafe {
+                encode_config
+                    .encodeCodecConfig
+                    .h264Config
+                    .set_repeatSPSPPS(self.repeat_spspps as u32);
+            },
+            EncodeCodec::Hevc =>
+            // SAFETY: We checked the codec is HEVC, so we can access the union field.
+            unsafe {
+                encode_config
+                    .encodeCodecConfig
+                    .hevcConfig
+                    .set_repeatSPSPPS(self.repeat_spspps as u32);
+            },
+        }
+    }
 }

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -107,9 +107,10 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum EncodeRateControlMode {
     ConstantQp,
+    #[default]
     VariableBitrate,
     ConstantBitrate,
 }
@@ -125,9 +126,10 @@ impl From<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
 }
 
 /// Tuning information of NVENC encoding (not applicable to H264 and HEVC MEOnly mode).
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum EncodeTuningInfo {
     HighQuality,
+    #[default]
     LowLatency,
     UltraLowLatency,
     Lossless,
@@ -146,6 +148,7 @@ impl From<EncodeTuningInfo> for NV_ENC_TUNING_INFO {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct EncodeRateControl {
     pub mode: EncodeRateControlMode,
     pub low_delay_key_frame_scale: u8,
@@ -153,6 +156,7 @@ pub struct EncodeRateControl {
     pub enable_aq: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct NvEncoderParams {
     pub codec: EncodeCodec,
     pub preset: EncodePreset,

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -1,4 +1,5 @@
 use super::{NvEncError, NvEncoderError};
+use crate::guids::{EncodeCodec, EncodePreset};
 use ffi::_NV_ENC_BUFFER_FORMAT;
 use nv_video_codec_sys::{
     self as ffi, NV_ENC_PARAMS_RC_MODE, NV_ENC_PIC_FLAGS, NV_ENC_TUNING_INFO,
@@ -143,4 +144,20 @@ impl From<EncodeTuningInfo> for NV_ENC_TUNING_INFO {
             EncodeTuningInfo::Lossless => NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_LOSSLESS,
         }
     }
+}
+
+pub struct EncodeRateControl {
+    pub mode: EncodeRateControlMode,
+    pub low_delay_key_frame_scale: u8,
+    pub average_bit_rate: u32,
+    pub enable_aq: bool,
+}
+
+pub struct NvEncoderParams {
+    pub codec: EncodeCodec,
+    pub preset: EncodePreset,
+    pub tuning_info: EncodeTuningInfo,
+    pub frame_rate: u32,
+    pub repeat_spspps: bool,
+    pub rate_control: EncodeRateControl,
 }

--- a/nv-video-codec/src/guids.rs
+++ b/nv-video-codec/src/guids.rs
@@ -7,6 +7,7 @@ use nv_video_codec_sys::{
 };
 
 #[non_exhaustive]
+#[derive(Clone, Copy)]
 pub enum EncodeCodec {
     H264,
     Hevc,
@@ -22,6 +23,7 @@ impl EncodeCodec {
 }
 
 #[non_exhaustive]
+#[derive(Clone, Copy)]
 pub enum EncodeProfile {
     AutoSelect,
 }
@@ -44,6 +46,7 @@ impl EncodeProfile {
 ///
 /// https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/nvenc-video-encoder-api-prog-guide/index.html#multi-nvenc-split-frame-encoding-in-hevc-and-av1
 #[non_exhaustive]
+#[derive(Clone, Copy)]
 pub enum EncodePreset {
     P1,
     P3,

--- a/nv-video-codec/src/guids.rs
+++ b/nv-video-codec/src/guids.rs
@@ -7,9 +7,10 @@ use nv_video_codec_sys::{
 };
 
 #[non_exhaustive]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum EncodeCodec {
     H264,
+    #[default]
     Hevc,
 }
 
@@ -23,8 +24,9 @@ impl EncodeCodec {
 }
 
 #[non_exhaustive]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum EncodeProfile {
+    #[default]
     AutoSelect,
 }
 
@@ -46,9 +48,10 @@ impl EncodeProfile {
 ///
 /// https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/nvenc-video-encoder-api-prog-guide/index.html#multi-nvenc-split-frame-encoding-in-hevc-and-av1
 #[non_exhaustive]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum EncodePreset {
     P1,
+    #[default]
     P3,
     P7,
 }

--- a/nv-video-codec/tests/encoder.rs
+++ b/nv-video-codec/tests/encoder.rs
@@ -57,13 +57,13 @@ fn util_create_encoder(encoder: &mut NvEncoderGL) -> Result<()> {
         // needs testing on dev installation
         tuning_info: EncodeTuningInfo::UltraLowLatency,
         frame_rate: 60,
+        // required for use with ffmpeg, not with nvcodec
         repeat_spspps: true,
         rate_control: EncodeRateControl {
             mode: EncodeRateControlMode::ConstantBitrate,
             low_delay_key_frame_scale: 1,
             average_bit_rate: 13_000_000,
             enable_aq: true,
-            // required for use with ffmpeg, not with nvcodec
         },
     };
 

--- a/nv-video-codec/tests/encoder.rs
+++ b/nv-video-codec/tests/encoder.rs
@@ -7,21 +7,20 @@ extern crate simple_logger;
 #[macro_use]
 mod utils;
 
-use std::{
-    io::Write,
-    time::{Duration, Instant},
-};
-
 use anyhow::Result;
 use glutin::{event_loop::EventLoop, platform::unix::EventLoopExtUnix, Context, PossiblyCurrent};
 use nv_video_codec::{
     encoder::{
-        types::BufferFormat, EncodePicFlags, EncodeRateControlMode, EncodeTuningInfo, NvEncoderExt,
-        NvEncoderGL,
+        types::BufferFormat, EncodePicFlags, EncodeRateControl, EncodeRateControlMode,
+        EncodeTuningInfo, NvEncoderExt, NvEncoderGL, NvEncoderParams,
     },
     guids::{EncodeCodec, EncodePreset},
 };
 use simple_logger::SimpleLogger;
+use std::{
+    io::Write,
+    time::{Duration, Instant},
+};
 
 struct GlEncoderContext {
     encoder: NvEncoderGL,
@@ -48,31 +47,28 @@ fn util_init_encoder(width: u32, height: u32, format: BufferFormat) -> Result<Gl
 }
 
 fn util_create_encoder(encoder: &mut NvEncoderGL) -> Result<()> {
-    let mut params = encoder.create_default_encoder_params(
-        EncodeCodec::Hevc,
+    let params = NvEncoderParams {
+        codec: EncodeCodec::Hevc,
         // preset guid seems to have no real effect on the speed???
         // needs testing as well
-        EncodePreset::P3,
+        preset: EncodePreset::P3,
         // can't really see a difference between ULTRA_LOW_LATENCY and LOW_LATENCY???
         // ULTRA_LOW might be like 0.5ms faster at times?
         // needs testing on dev installation
-        EncodeTuningInfo::UltraLowLatency,
-    )?;
-    params.frameRateNum = 60;
-    unsafe {
-        (*params.encodeConfig).rcParams.rateControlMode =
-            EncodeRateControlMode::ConstantBitrate.into();
-        // (*params.encodeConfig).rcParams.multiPass =
-        //     NV_ENC_MULTI_PASS::NV_ENC_TWO_PASS_QUARTER_RESOLUTION;
-        (*params.encodeConfig).rcParams.lowDelayKeyFrameScale = 1;
-        (*params.encodeConfig).rcParams.averageBitRate = 13 * 1000 * 1000;
-        (*params.encodeConfig).rcParams.vbvBufferSize = encoder.get_frame_size()?;
-        (*params.encodeConfig).rcParams.vbvInitialDelay = encoder.get_frame_size()?;
-        (*params.encodeConfig).rcParams.set_enableAQ(1);
-        // required for use with ffmpeg, not with nvcodec
-        (*params.encodeConfig).encodeCodecConfig.hevcConfig.set_repeatSPSPPS(1);
-    }
+        tuning_info: EncodeTuningInfo::UltraLowLatency,
+        frame_rate: 60,
+        repeat_spspps: true,
+        rate_control: EncodeRateControl {
+            mode: EncodeRateControlMode::ConstantBitrate,
+            low_delay_key_frame_scale: 1,
+            average_bit_rate: 13_000_000,
+            enable_aq: true,
+            // required for use with ffmpeg, not with nvcodec
+        },
+    };
+
     encoder.create_encoder(&params)?;
+
     Ok(())
 }
 

--- a/nv-video-codec/tests/encoder.rs
+++ b/nv-video-codec/tests/encoder.rs
@@ -67,7 +67,7 @@ fn util_create_encoder(encoder: &mut NvEncoderGL) -> Result<()> {
         },
     };
 
-    encoder.create_encoder(&params)?;
+    encoder.create_encoder(params)?;
 
     Ok(())
 }


### PR DESCRIPTION
Another part of #16  

Expose just a few common encoder options, do not force users to understand the complex FFI type.