### PR TITLE
Switch to cudarc

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ impl NvDecoder {
 ```
 
 1. `NvDecoder` can be obtained with `NvDecoder::builder().x().y().z().build()`, provided a
-   `rustacuda` `Context` has been created.
+   `cudarc` `CudaContext` has been created.
 1. The decoder is then fed with `NvDecoder::decode(data, ...)`, which makes it parse and process
    the `data`.
 1. If decoding is successful the results can be queried with methods like `NvDecoder::get_width()`,

--- a/nv-video-codec/Cargo.toml
+++ b/nv-video-codec/Cargo.toml
@@ -15,7 +15,7 @@ cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-g
 gl = "0.14"
 nv-video-codec-sys = { path = "../nv-video-codec-sys" }
 parking_lot = "0.11"
-cudarc = { version = "0.19", features = ["cuda-version-from-build-system"] }
+cudarc = { version = "0.19", features = ["cuda-version-from-build-system", "dynamic-linking"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/nv-video-codec/Cargo.toml
+++ b/nv-video-codec/Cargo.toml
@@ -15,11 +15,7 @@ cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-g
 gl = "0.14"
 nv-video-codec-sys = { path = "../nv-video-codec-sys" }
 parking_lot = "0.11"
-# TODO(mbernat): Move to a modern alternative like cudarc.
-# 0.1.3 introduces a conflict between cuda-sys and cuda-driver-sys, both of which are archived crates.
-rustacuda = "0.1.2"
-rustacuda_core = "0.1"
-rustacuda_derive = "0.1"
+cudarc = { version = "0.19", features = ["cuda-version-from-build-system"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/nv-video-codec/Cargo.toml
+++ b/nv-video-codec/Cargo.toml
@@ -11,7 +11,7 @@ torture = []
 
 [dependencies]
 bitflags = "1.2"
-cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-gl-interop" }
+cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-gl-interop", branch="cudarc" }
 gl = "0.14"
 nv-video-codec-sys = { path = "../nv-video-codec-sys" }
 parking_lot = "0.11"

--- a/nv-video-codec/src/common/mod.rs
+++ b/nv-video-codec/src/common/mod.rs
@@ -2,5 +2,6 @@
 mod macros;
 
 pub mod cuda_result;
+pub mod util;
 
 pub use cuda_result::*;

--- a/nv-video-codec/src/common/util.rs
+++ b/nv-video-codec/src/common/util.rs
@@ -1,0 +1,22 @@
+use cudarc::driver::{
+    sys::{cuCtxPopCurrent_v2, cuCtxPushCurrent_v2, CUcontext},
+    CudaContext, DriverError,
+};
+use std::ptr::null_mut;
+
+pub(crate) struct ContextStack;
+
+impl ContextStack {
+    pub(crate) fn push(ctx: &CudaContext) -> Result<(), DriverError> {
+        let cu_ctx = ctx.cu_ctx();
+        let result = unsafe { cuCtxPushCurrent_v2(cu_ctx) };
+        result.result()
+    }
+
+    pub(crate) fn pop() -> Result<(), DriverError> {
+        let mut cu_ctx: CUcontext = null_mut();
+        let result = unsafe { cuCtxPopCurrent_v2(&raw mut cu_ctx) };
+
+        result.result()
+    }
+}

--- a/nv-video-codec/src/decoder/builder.rs
+++ b/nv-video-codec/src/decoder/builder.rs
@@ -1,13 +1,13 @@
-use rustacuda::context::Context;
-
 use super::{
     types::{Codec, Dim, Rect},
     NvDecoder, NvDecoderError,
 };
 use crate::decoder::frame::FrameAllocator;
+use cudarc::driver::CudaContext;
+use std::sync::Arc;
 
 pub struct NvDecoderBuilder {
-    pub(super) context: Context,
+    pub(super) context: Arc<CudaContext>,
     pub(super) codec: Codec,
     pub(super) low_latency: bool,
     pub(super) crop_rect: Rect,
@@ -30,7 +30,7 @@ impl NvDecoderBuilder {
 
     builder_field_setter!(clock_rate: u32);
 
-    pub fn new(context: Context, codec: Codec) -> Self {
+    pub fn new(context: Arc<CudaContext>, codec: Codec) -> Self {
         Self {
             context,
             codec,

--- a/nv-video-codec/src/decoder/nvdecoder.rs
+++ b/nv-video-codec/src/decoder/nvdecoder.rs
@@ -1,11 +1,15 @@
-use super::types::{ChromaFormat, Codec, CreateFlags, DeinterlaceMode, Dim, Rect, SurfaceFormat};
+use super::{
+    types::{ChromaFormat, Codec, CreateFlags, DeinterlaceMode, Dim, Rect, SurfaceFormat},
+    DecoderPacketFlags, NvDecoderError,
+};
 use crate::{
-    common::cuda_result::IntoCudaResult,
+    common::{cuda_result::IntoCudaResult, util::ContextStack},
     decoder::{
         frame::{info::FrameInfo, Buffer as _, DecodingOutput, Frame, FrameAllocator, OwnedFrame},
         NvDecoderBuilder,
     },
 };
+use cudarc::driver::CudaContext;
 use ffi::{
     cuMemcpy2DAsync_v2, cuStreamSynchronize, cudaVideoCreateFlags_enum, cuvidCreateDecoder,
     cuvidCtxLockCreate, cuvidCtxLockDestroy, cuvidDecodePicture, cuvidDecodeStatus_enum,
@@ -18,20 +22,18 @@ use ffi::{
     CUVIDPICPARAMS, CUVIDPROCPARAMS, CUVIDSOURCEDATAPACKET,
 };
 use nv_video_codec_sys as ffi;
-use rustacuda::context::{Context, ContextHandle, ContextStack};
 use std::{
     collections::VecDeque,
     convert::TryInto,
     os::raw::{c_int, c_ulong, c_void},
+    sync::Arc,
     time::Instant,
 };
-
-use super::{DecoderPacketFlags, NvDecoderError};
 
 pub struct NvDecoder<A: FrameAllocator> {
     parser: CUvideoparser,
     decoder: CUvideodecoder,
-    context: Context,
+    context: Arc<CudaContext>,
     codec: Codec,
     chroma_format: ChromaFormat,
     video_format: CUVIDEOFORMAT,
@@ -101,7 +103,7 @@ unsafe extern "C" fn handle_operating_point_proc<A: FrameAllocator>(
     (decoder as *mut NvDecoder<A>).as_mut().unwrap().handle_operating_point(op_info)
 }
 
-fn do_within_context<F, T>(context: &Context, mut func: F)
+fn do_within_context<F, T>(context: &CudaContext, mut func: F)
 where
     F: FnMut() -> T,
     T: IntoCudaResult<()>,
@@ -511,7 +513,7 @@ impl<A: FrameAllocator> NvDecoder<A> {
     pub(super) fn new(builder: NvDecoderBuilder) -> Result<Box<Self>, NvDecoderError> {
         let ctx_lock = unsafe {
             let mut ctx_lock = std::ptr::null_mut();
-            cuvidCtxLockCreate(&mut ctx_lock, builder.context.get_inner() as *mut ffi::CUctx_st)
+            cuvidCtxLockCreate(&mut ctx_lock, builder.context.cu_ctx() as *mut ffi::CUctx_st)
                 .into_cuda_result()?;
             ctx_lock
         };

--- a/nv-video-codec/src/encoder/nvencodercuda.rs
+++ b/nv-video-codec/src/encoder/nvencodercuda.rs
@@ -3,18 +3,16 @@ use super::{
     NvEncoderResult,
 };
 use crate::{
-    common::IntoCudaResult,
+    common::{util::ContextStack, IntoCudaResult},
     encoder::nvencoder::{Device, Input, NvEncInputFrame, NvEncoderSettings},
 };
 use cuda_gl_interop::{CudaSliceMut, Size};
+use cudarc::driver::CudaContext;
 use nv_video_codec_sys::{cuMemAllocPitch_v2, cuMemFree_v2, CUdeviceptr, _NV_ENC_DEVICE_TYPE};
-use rustacuda::{
-    context::{ContextHandle as _, ContextStack},
-    prelude::Context,
-};
 use std::{
     ffi::c_void,
     ops::{Deref, DerefMut},
+    sync::Arc,
 };
 
 pub struct NvEncoderCuda {
@@ -36,11 +34,11 @@ impl DerefMut for NvEncoderCuda {
 }
 
 impl NvEncoderCuda {
-    pub fn new(context: Context, settings: NvEncoderSettings) -> NvEncoderResult<Self> {
+    pub fn new(context: Arc<CudaContext>, settings: NvEncoderSettings) -> NvEncoderResult<Self> {
         Ok(Self {
             encoder: NvEncoder::new(
                 _NV_ENC_DEVICE_TYPE::NV_ENC_DEVICE_TYPE_CUDA,
-                context.get_inner() as *mut Device,
+                context.cu_ctx() as *mut Device,
                 context,
                 settings,
             )?,
@@ -100,7 +98,7 @@ pub struct NvEncoderCudaResourceManager {}
 impl NvEncoderResourceManager for NvEncoderCudaResourceManager {
     type InputResource = CUdeviceptr;
     type InputResourceRef<'a> = CudaSliceMut<'a>;
-    type ResourceContext = Context;
+    type ResourceContext = Arc<CudaContext>;
 
     fn allocate_input_buffers(
         encoder: &mut NvEncoder<Self>,

--- a/nv-video-codec/src/lib.rs
+++ b/nv-video-codec/src/lib.rs
@@ -5,11 +5,8 @@ extern crate thiserror;
 #[macro_use]
 extern crate bitflags;
 
+extern crate cudarc;
 extern crate gl;
-extern crate rustacuda;
-
-extern crate rustacuda_core;
-extern crate rustacuda_derive;
 
 extern crate parking_lot;
 

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -4,6 +4,7 @@ extern crate log;
 extern crate simple_logger;
 
 use anyhow::Result;
+use cudarc::driver::{sys::CUctx_flags, CudaContext};
 use nv_video_codec::{
     encoder::{
         nvencodercuda::NvEncoderCuda, types::BufferFormat, EncodePicFlags, EncodeRateControl,
@@ -11,13 +12,10 @@ use nv_video_codec::{
     },
     guids::{EncodeCodec, EncodePreset},
 };
-use rustacuda::{
-    device::Device,
-    prelude::{Context, ContextFlags},
-};
 use simple_logger::SimpleLogger;
 use std::{
     io::Write,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -25,11 +23,9 @@ use std::{
 #[macro_use]
 mod utils;
 
-fn init_cuda_ctx() -> Result<Context> {
-    rustacuda::init(rustacuda::CudaFlags::empty())?;
-    let device = Device::get_device(0)?;
-    let context =
-        Context::create_and_push(ContextFlags::MAP_HOST | ContextFlags::SCHED_AUTO, device)?;
+fn init_cuda_ctx() -> Result<Arc<CudaContext>> {
+    let context = CudaContext::new(0)?;
+    context.set_flags(CUctx_flags::CU_CTX_MAP_HOST)?;
     Ok(context)
 }
 

--- a/nv-video-codec/tests/decoder.rs
+++ b/nv-video-codec/tests/decoder.rs
@@ -3,18 +3,15 @@ extern crate log;
 extern crate simple_logger;
 
 use anyhow::Result;
+use cudarc::driver::{sys::CUctx_flags, CudaContext};
 use nv_video_codec::decoder::{
     frame::{
         device::DeviceFrameAllocator, host::HostFrameAllocator, DecodingOutput, FrameAllocator,
     },
     DecoderPacketFlags, NvDecoderBuilder,
 };
-use rustacuda::{
-    context::{Context, ContextFlags},
-    device::Device,
-};
 use simple_logger::SimpleLogger;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 #[path = "utils.rs"]
 #[macro_use]
@@ -24,11 +21,9 @@ mod utils;
 // From NVPipe: Some cuvid implementations have one frame latency. Refeed frame into pipeline in this case.
 const DECODE_TRIES: usize = 3;
 
-fn init_cuda_ctx() -> Result<Context> {
-    rustacuda::init(rustacuda::CudaFlags::empty())?;
-    let device = Device::get_device(0)?;
-    let context =
-        Context::create_and_push(ContextFlags::MAP_HOST | ContextFlags::SCHED_AUTO, device)?;
+fn init_cuda_ctx() -> Result<Arc<CudaContext>> {
+    let context = CudaContext::new(0)?;
+    context.set_flags(CUctx_flags::CU_CTX_MAP_HOST)?;
     Ok(context)
 }
 


### PR DESCRIPTION
Close #47 

The only non-trivial parts are the custom push/pop context impls. I'm not sure why the calls are even needed (perhaps in case of multi-context multi-threaded juggling). The calls seem rarely used in the wild, which is likely why cudarc doesn't provide safe wrappers in the first place. But for now I kept them.