### PR TITLE
Expose more rate control params

### DIFF
--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -390,7 +390,7 @@ where
         }
 
         initialize_params.frameRateNum = params.frame_rate;
-        params.apply_to_encode_config(self.get_frame_size()?, &mut encode_config);
+        params.apply_to_encode_config(&mut encode_config);
         Self::validate_encode_config(encode_config, params.codec, self.buffer_format)?;
 
         Ok((initialize_params, encode_config))

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -109,18 +109,28 @@ bitflags! {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum EncodeRateControlMode {
-    ConstantQp,
     #[default]
+    ConstantQp,
     VariableBitrate,
     ConstantBitrate,
+    ConstantBitrateLowDelayHighQuality,
+    ConstantBitrateHighQuality,
+    VariableBitrateHighQuality,
 }
 
 impl From<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
     fn from(value: EncodeRateControlMode) -> Self {
+        use NV_ENC_PARAMS_RC_MODE as MODE;
+
         match value {
-            EncodeRateControlMode::ConstantQp => NV_ENC_PARAMS_RC_MODE::NV_ENC_PARAMS_RC_CONSTQP,
-            EncodeRateControlMode::VariableBitrate => NV_ENC_PARAMS_RC_MODE::NV_ENC_PARAMS_RC_VBR,
-            EncodeRateControlMode::ConstantBitrate => NV_ENC_PARAMS_RC_MODE::NV_ENC_PARAMS_RC_CBR,
+            EncodeRateControlMode::ConstantQp => MODE::NV_ENC_PARAMS_RC_CONSTQP,
+            EncodeRateControlMode::VariableBitrate => MODE::NV_ENC_PARAMS_RC_VBR,
+            EncodeRateControlMode::ConstantBitrate => MODE::NV_ENC_PARAMS_RC_CBR,
+            EncodeRateControlMode::ConstantBitrateLowDelayHighQuality => {
+                MODE::NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ
+            },
+            EncodeRateControlMode::ConstantBitrateHighQuality => MODE::NV_ENC_PARAMS_RC_CBR_HQ,
+            EncodeRateControlMode::VariableBitrateHighQuality => MODE::NV_ENC_PARAMS_RC_VBR_HQ,
         }
     }
 }
@@ -148,11 +158,13 @@ impl From<EncodeTuningInfo> for NV_ENC_TUNING_INFO {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EncodeRateControl {
     pub mode: EncodeRateControlMode,
     pub low_delay_key_frame_scale: u8,
-    pub average_bit_rate: u32,
+    pub bit_rate: u32,
+    pub vbv_buffer_size_bits: u32,
+    pub vbv_buffer_initial_delay: u32,
     pub enable_aq: bool,
 }
 
@@ -167,16 +179,13 @@ pub struct NvEncoderParams {
 }
 
 impl NvEncoderParams {
-    pub(crate) fn apply_to_encode_config(
-        &self,
-        frame_size: u32,
-        encode_config: &mut NV_ENC_CONFIG,
-    ) {
+    pub(crate) fn apply_to_encode_config(&self, encode_config: &mut NV_ENC_CONFIG) {
         encode_config.rcParams.rateControlMode = self.rate_control.mode.into();
         encode_config.rcParams.lowDelayKeyFrameScale = self.rate_control.low_delay_key_frame_scale;
-        encode_config.rcParams.averageBitRate = self.rate_control.average_bit_rate;
-        encode_config.rcParams.vbvBufferSize = frame_size;
-        encode_config.rcParams.vbvInitialDelay = frame_size;
+        encode_config.rcParams.averageBitRate = self.rate_control.bit_rate;
+        encode_config.rcParams.averageBitRate = self.rate_control.bit_rate;
+        encode_config.rcParams.vbvBufferSize = self.rate_control.vbv_buffer_size_bits;
+        encode_config.rcParams.vbvInitialDelay = self.rate_control.vbv_buffer_initial_delay;
         encode_config.rcParams.set_enableAQ(self.rate_control.enable_aq as u32);
 
         match self.codec {

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -201,6 +201,7 @@ impl NvEncoderParams {
         encode_config.rcParams.vbvBufferSize = self.rate_control.vbv_buffer_size_bits;
         encode_config.rcParams.vbvInitialDelay = self.rate_control.vbv_buffer_initial_delay;
         encode_config.rcParams.set_enableAQ(self.rate_control.enable_aq as u32);
+        encode_config.rcParams.multiPass = self.rate_control.multi_pass.into();
 
         match self.codec {
             EncodeCodec::H264 =>

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -2,7 +2,8 @@ use super::{NvEncError, NvEncoderError};
 use crate::guids::{EncodeCodec, EncodePreset};
 use ffi::_NV_ENC_BUFFER_FORMAT;
 use nv_video_codec_sys::{
-    self as ffi, NV_ENC_CONFIG, NV_ENC_PARAMS_RC_MODE, NV_ENC_PIC_FLAGS, NV_ENC_TUNING_INFO,
+    self as ffi, NV_ENC_CONFIG, NV_ENC_MULTI_PASS, NV_ENC_PARAMS_RC_MODE, NV_ENC_PIC_FLAGS,
+    NV_ENC_TUNING_INFO,
 };
 
 ffi_enum! {
@@ -113,9 +114,6 @@ pub enum EncodeRateControlMode {
     ConstantQp,
     VariableBitrate,
     ConstantBitrate,
-    ConstantBitrateLowDelayHighQuality,
-    ConstantBitrateHighQuality,
-    VariableBitrateHighQuality,
 }
 
 impl From<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
@@ -126,11 +124,26 @@ impl From<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
             EncodeRateControlMode::ConstantQp => MODE::NV_ENC_PARAMS_RC_CONSTQP,
             EncodeRateControlMode::VariableBitrate => MODE::NV_ENC_PARAMS_RC_VBR,
             EncodeRateControlMode::ConstantBitrate => MODE::NV_ENC_PARAMS_RC_CBR,
-            EncodeRateControlMode::ConstantBitrateLowDelayHighQuality => {
-                MODE::NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ
-            },
-            EncodeRateControlMode::ConstantBitrateHighQuality => MODE::NV_ENC_PARAMS_RC_CBR_HQ,
-            EncodeRateControlMode::VariableBitrateHighQuality => MODE::NV_ENC_PARAMS_RC_VBR_HQ,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum EncodeMultiPass {
+    #[default]
+    Disabled,
+    TwoPassQuarterResolution,
+    TwoPassFullResolution,
+}
+
+impl From<EncodeMultiPass> for NV_ENC_MULTI_PASS {
+    fn from(value: EncodeMultiPass) -> Self {
+        use NV_ENC_MULTI_PASS as PASS;
+
+        match value {
+            EncodeMultiPass::Disabled => PASS::NV_ENC_MULTI_PASS_DISABLED,
+            EncodeMultiPass::TwoPassQuarterResolution => PASS::NV_ENC_TWO_PASS_QUARTER_RESOLUTION,
+            EncodeMultiPass::TwoPassFullResolution => PASS::NV_ENC_TWO_PASS_FULL_RESOLUTION,
         }
     }
 }
@@ -166,6 +179,7 @@ pub struct EncodeRateControl {
     pub vbv_buffer_size_bits: u32,
     pub vbv_buffer_initial_delay: u32,
     pub enable_aq: bool,
+    pub multi_pass: EncodeMultiPass,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -197,7 +197,7 @@ impl NvEncoderParams {
         encode_config.rcParams.rateControlMode = self.rate_control.mode.into();
         encode_config.rcParams.lowDelayKeyFrameScale = self.rate_control.low_delay_key_frame_scale;
         encode_config.rcParams.averageBitRate = self.rate_control.bit_rate;
-        encode_config.rcParams.averageBitRate = self.rate_control.bit_rate;
+        encode_config.rcParams.maxBitRate = self.rate_control.bit_rate;
         encode_config.rcParams.vbvBufferSize = self.rate_control.vbv_buffer_size_bits;
         encode_config.rcParams.vbvInitialDelay = self.rate_control.vbv_buffer_initial_delay;
         encode_config.rcParams.set_enableAQ(self.rate_control.enable_aq as u32);

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -7,8 +7,9 @@ use anyhow::Result;
 use cudarc::driver::{sys::CUctx_flags, CudaContext};
 use nv_video_codec::{
     encoder::{
-        nvencodercuda::NvEncoderCuda, types::BufferFormat, EncodePicFlags, EncodeRateControl,
-        EncodeRateControlMode, EncodeTuningInfo, NvEncoderParams, NvEncoderSettings,
+        nvencodercuda::NvEncoderCuda, types::BufferFormat, EncodeMultiPass, EncodePicFlags,
+        EncodeRateControl, EncodeRateControlMode, EncodeTuningInfo, NvEncoderParams,
+        NvEncoderSettings,
     },
     guids::{EncodeCodec, EncodePreset},
 };
@@ -55,6 +56,7 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
             low_delay_key_frame_scale: 1,
             bit_rate: 13_000_000,
             enable_aq: true,
+            multi_pass: EncodeMultiPass::TwoPassFullResolution,
             ..Default::default()
         },
     };

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -53,8 +53,9 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
         rate_control: EncodeRateControl {
             mode: EncodeRateControlMode::ConstantBitrate,
             low_delay_key_frame_scale: 1,
-            average_bit_rate: 13_000_000,
+            bit_rate: 13_000_000,
             enable_aq: true,
+            ..Default::default()
         },
     };
 

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -7,8 +7,9 @@ use anyhow::Result;
 use cudarc::driver::{sys::CUctx_flags, CudaContext};
 use nv_video_codec::{
     encoder::{
-        nvencodercuda::NvEncoderCuda, types::BufferFormat, EncodePicFlags, EncodeRateControl,
-        EncodeRateControlMode, EncodeTuningInfo, NvEncoderParams, NvEncoderSettings,
+        nvencodercuda::NvEncoderCuda, types::BufferFormat, EncodeMultiPass, EncodePicFlags,
+        EncodeRateControl, EncodeRateControlMode, EncodeTuningInfo, NvEncoderParams,
+        NvEncoderSettings,
     },
     guids::{EncodeCodec, EncodePreset},
 };
@@ -54,6 +55,7 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
             low_delay_key_frame_scale: 1,
             bit_rate: 13_000_000,
             enable_aq: true,
+            multi_pass: EncodeMultiPass::TwoPassFullResolution,
             ..Default::default()
         },
     };

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -52,8 +52,9 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
         rate_control: EncodeRateControl {
             mode: EncodeRateControlMode::ConstantBitrate,
             low_delay_key_frame_scale: 1,
-            average_bit_rate: 13_000_000,
+            bit_rate: 13_000_000,
             enable_aq: true,
+            ..Default::default()
         },
     };
 

--- a/nv-video-codec/tests/gl_encoder.rs
+++ b/nv-video-codec/tests/gl_encoder.rs
@@ -63,8 +63,9 @@ fn util_create_encoder(encoder: &mut NvEncoderGL) -> Result<()> {
         rate_control: EncodeRateControl {
             mode: EncodeRateControlMode::ConstantBitrate,
             low_delay_key_frame_scale: 1,
-            average_bit_rate: 13_000_000,
+            bit_rate: 13_000_000,
             enable_aq: true,
+            ..Default::default()
         },
     };
 

--- a/nv-video-codec/tests/gl_encoder.rs
+++ b/nv-video-codec/tests/gl_encoder.rs
@@ -60,8 +60,9 @@ fn util_create_encoder(encoder: &mut NvEncoderGL) -> Result<()> {
         rate_control: EncodeRateControl {
             mode: EncodeRateControlMode::ConstantBitrate,
             low_delay_key_frame_scale: 1,
-            average_bit_rate: 13_000_000,
+            bit_rate: 13_000_000,
             enable_aq: true,
+            ..Default::default()
         },
     };
 


### PR DESCRIPTION
Keeping parity with our nvpipe settings.

```cpp
                encodeConfig.rcParams.rateControlMode = NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ;

                encodeConfig.rcParams.averageBitRate = this->bitrate;
                encodeConfig.rcParams.maxBitRate = this->bitrate;

                // Bitrate / framerate = one frame.
                uint32_t oneFrameSize = this->bitrate / this->targetFrameRate;
                encodeConfig.rcParams.vbvBufferSize = oneFrameSize;
                encodeConfig.rcParams.vbvInitialDelay = oneFrameSize;
```