### PR TITLE
Implement set_bitrate_and_frame_rate()

### DIFF
--- a/nv-video-codec/Cargo.toml
+++ b/nv-video-codec/Cargo.toml
@@ -11,7 +11,7 @@ torture = []
 
 [dependencies]
 bitflags = "1.2"
-cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-gl-interop", branch="cudarc" }
+cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-gl-interop", branch="cuda-slice-getters" }
 gl = "0.14"
 nv-video-codec-sys = { path = "../nv-video-codec-sys" }
 parking_lot = "0.11"

--- a/nv-video-codec/Cargo.toml
+++ b/nv-video-codec/Cargo.toml
@@ -11,7 +11,7 @@ torture = []
 
 [dependencies]
 bitflags = "1.2"
-cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-gl-interop", branch="cuda-slice-getters" }
+cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-gl-interop" }
 gl = "0.14"
 log = "0.4"
 nv-video-codec-sys = { path = "../nv-video-codec-sys" }

--- a/nv-video-codec/Cargo.toml
+++ b/nv-video-codec/Cargo.toml
@@ -11,7 +11,7 @@ torture = []
 
 [dependencies]
 bitflags = "1.2"
-cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-gl-interop"}
+cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-gl-interop", branch="cuda-slice-getters" }
 gl = "0.14"
 log = "0.4"
 nv-video-codec-sys = { path = "../nv-video-codec-sys" }

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -9,16 +9,17 @@ use crate::{
     guids::EncodeCodec,
 };
 use nv_video_codec_sys::{
-    NvEncodeAPICreateInstance, NvEncodeAPIGetMaxSupportedVersion, _NV_ENC_PIC_STRUCT, GUID,
-    NVENCAPI_MAJOR_VERSION, NVENCAPI_MINOR_VERSION, NVENCAPI_VERSION, NVENC_INFINITE_GOPLENGTH,
-    NV_ENCODE_API_FUNCTION_LIST, NV_ENC_BUFFER_USAGE, NV_ENC_CAPS, NV_ENC_CAPS_PARAM,
-    NV_ENC_CONFIG, NV_ENC_CREATE_BITSTREAM_BUFFER, NV_ENC_CREATE_MV_BUFFER, NV_ENC_DEVICE_TYPE,
-    NV_ENC_INITIALIZE_PARAMS, NV_ENC_INPUT_PTR, NV_ENC_INPUT_RESOURCE_TYPE, NV_ENC_LOCK_BITSTREAM,
-    NV_ENC_MAP_INPUT_RESOURCE, NV_ENC_MEONLY_PARAMS, NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS,
-    NV_ENC_OUTPUT_PTR, NV_ENC_PIC_PARAMS, NV_ENC_PRESET_CONFIG, NV_ENC_QP, NV_ENC_REGISTERED_PTR,
-    NV_ENC_REGISTER_RESOURCE,
+    NvEncodeAPICreateInstance, NvEncodeAPIGetMaxSupportedVersion, _NV_ENC_PIC_STRUCT,
+    _NV_ENC_RECONFIGURE_PARAMS, GUID, NVENCAPI_MAJOR_VERSION, NVENCAPI_MINOR_VERSION,
+    NVENCAPI_VERSION, NVENC_INFINITE_GOPLENGTH, NV_ENCODE_API_FUNCTION_LIST, NV_ENC_BUFFER_USAGE,
+    NV_ENC_CAPS, NV_ENC_CAPS_PARAM, NV_ENC_CONFIG, NV_ENC_CREATE_BITSTREAM_BUFFER,
+    NV_ENC_CREATE_MV_BUFFER, NV_ENC_DEVICE_TYPE, NV_ENC_INITIALIZE_PARAMS, NV_ENC_INPUT_PTR,
+    NV_ENC_INPUT_RESOURCE_TYPE, NV_ENC_LOCK_BITSTREAM, NV_ENC_MAP_INPUT_RESOURCE,
+    NV_ENC_MEONLY_PARAMS, NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS, NV_ENC_OUTPUT_PTR,
+    NV_ENC_PIC_PARAMS, NV_ENC_PRESET_CONFIG, NV_ENC_QP, NV_ENC_RECONFIGURE_PARAMS,
+    NV_ENC_REGISTERED_PTR, NV_ENC_REGISTER_RESOURCE,
 };
-use std::{ffi::c_void, marker::PhantomData};
+use std::{ffi::c_void, marker::PhantomData, ptr::null_mut};
 
 pub(super) const fn nvenc_api_struct_version(version: u32) -> u32 {
     NVENCAPI_VERSION | ((version) << 16) | (0x7 << 28)
@@ -27,6 +28,7 @@ pub(super) const fn nvenc_api_struct_version(version: u32) -> u32 {
 const NV_ENCODE_API_FUNCTION_LIST_VERSION: u32 = nvenc_api_struct_version(2);
 const NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER: u32 = nvenc_api_struct_version(1);
 const NV_ENC_INITIALIZE_PARAMS_VER: u32 = nvenc_api_struct_version(5) | (1 << 31);
+const NV_ENC_RECONFIGURE_PARAMS_VER: u32 = nvenc_api_struct_version(1) | (1 << 31);
 // TODO: just make these versions in the custom defaults
 pub(super) const NV_ENC_CONFIG_VER: u32 = nvenc_api_struct_version(7) | (1 << 31);
 pub(super) const NV_ENC_PRESET_CONFIG_VER: u32 = nvenc_api_struct_version(4) | (1 << 31);
@@ -37,6 +39,10 @@ const NV_ENC_CREATE_BITSTREAM_BUFFER_VER: u32 = nvenc_api_struct_version(1);
 const NV_ENC_CREATE_MV_BUFFER_VER: u32 = nvenc_api_struct_version(1);
 const NV_ENC_MAP_INPUT_RESOURCE_VER: u32 = nvenc_api_struct_version(4);
 const NV_ENC_REGISTER_RESOURCE_VER: u32 = nvenc_api_struct_version(3);
+
+// We accept frame rate as float, but NVENC API expects uint32 numerator and denominator. We set
+// a constant denominator as a tradeoff between precision and representable range.
+const FRAME_RATE_DENOMINATOR: u32 = 1000;
 
 #[repr(C)]
 pub(super) struct EncoderHandle {
@@ -88,6 +94,8 @@ where
     device: *mut Device, // Originally a void pointer
     device_type: NV_ENC_DEVICE_TYPE,
     encoder_initialized: bool,
+    initialize_params: NV_ENC_INITIALIZE_PARAMS,
+    encode_config: NV_ENC_CONFIG,
     extra_output_delay: u32,
     bitstream_output_buffer: Vec<NV_ENC_OUTPUT_PTR>,
     motion_vector_data_output_buffer: Vec<NV_ENC_OUTPUT_PTR>,
@@ -118,6 +126,10 @@ where
             )
             .into_nvenc_result()?;
         }
+
+        initialize_params.encodeConfig = null_mut();
+        self.initialize_params = initialize_params;
+        self.encode_config = encode_config;
 
         self.encoder_initialized = true;
 
@@ -156,10 +168,55 @@ where
         Ok(())
     }
 
-    // not implementing for now
-    // pub fn reconfigure() -> bool {
-    //     unimplemented!()
-    // }
+    pub fn set_bitrate_and_frame_rate(
+        &mut self,
+        bitrate: u32,
+        frame_rate: f64,
+    ) -> NvEncoderResult<()> {
+        let mut params = _NV_ENC_RECONFIGURE_PARAMS {
+            version: NV_ENC_RECONFIGURE_PARAMS_VER,
+            ..Default::default()
+        };
+
+        params.set_resetEncoder(1);
+        params.set_forceIDR(1);
+
+        self.initialize_params.frameRateNum = (frame_rate * FRAME_RATE_DENOMINATOR as f64) as u32;
+        self.initialize_params.frameRateDen = FRAME_RATE_DENOMINATOR;
+
+        self.encode_config.rcParams.averageBitRate = bitrate;
+        self.encode_config.rcParams.maxBitRate = bitrate;
+
+        let frame_size_in_bits = bitrate / frame_rate as u32;
+        self.encode_config.rcParams.vbvBufferSize = frame_size_in_bits;
+        self.encode_config.rcParams.vbvInitialDelay = frame_size_in_bits;
+
+        self.reconfigure(params)?;
+
+        Ok(())
+    }
+
+    fn reconfigure(&mut self, mut params: NV_ENC_RECONFIGURE_PARAMS) -> NvEncoderResult<()> {
+        self.initialize_params.encodeConfig = &raw mut self.encode_config;
+        params.reInitEncodeParams = self.initialize_params;
+
+        unsafe {
+            self.nv_encode_api_function_list.nvEncReconfigureEncoder.unwrap()(
+                self.encoder_handle as *mut c_void,
+                &raw mut params,
+            )
+            .into_nvenc_result()?;
+        }
+
+        self.initialize_params.encodeConfig = null_mut();
+
+        self.width = params.reInitEncodeParams.encodeWidth;
+        self.height = params.reInitEncodeParams.encodeHeight;
+        self.max_encode_width = params.reInitEncodeParams.maxEncodeWidth;
+        self.max_encode_height = params.reInitEncodeParams.maxEncodeHeight;
+
+        Ok(())
+    }
 
     // TODO: make this (and get_next_reference_frame) optional
     pub fn get_next_input_frame(&mut self) -> &mut NvEncInputFrame {
@@ -298,8 +355,8 @@ where
             encodeHeight: self.height,
             darWidth: self.width,
             darHeight: self.height,
-            frameRateNum: 30, // TODO(efyang): possible optimization?
-            frameRateDen: 1,
+            frameRateNum: (params.frame_rate * FRAME_RATE_DENOMINATOR as f64) as u32,
+            frameRateDen: FRAME_RATE_DENOMINATOR,
             enablePTD: 1,
             maxEncodeWidth: self.width,
             maxEncodeHeight: self.height,
@@ -389,7 +446,9 @@ where
             },
         }
 
-        initialize_params.frameRateNum = params.frame_rate;
+        // TODO: is this needed?
+        // initialize_params.frameRateNum = params.frame_rate;
+
         params.apply_to_encode_config(&mut encode_config);
         Self::validate_encode_config(encode_config, params.codec, self.buffer_format)?;
 
@@ -533,6 +592,8 @@ where
             device,
             device_type,
             encoder_initialized: false,
+            initialize_params: Default::default(),
+            encode_config: CustomDefault::default(),
             extra_output_delay,
             bitstream_output_buffer: Vec::new(),
             motion_vector_data_output_buffer: Vec::new(),

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -197,8 +197,8 @@ where
     }
 
     fn reconfigure(&mut self, mut params: NV_ENC_RECONFIGURE_PARAMS) -> NvEncoderResult<()> {
-        self.initialize_params.encodeConfig = &raw mut self.encode_config;
         params.reInitEncodeParams = self.initialize_params;
+        params.reInitEncodeParams.encodeConfig = &raw mut self.encode_config;
 
         unsafe {
             self.nv_encode_api_function_list.nvEncReconfigureEncoder.unwrap()(
@@ -207,8 +207,6 @@ where
             )
             .into_nvenc_result()?;
         }
-
-        self.initialize_params.encodeConfig = null_mut();
 
         self.width = params.reInitEncodeParams.encodeWidth;
         self.height = params.reInitEncodeParams.encodeHeight;

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -444,9 +444,6 @@ where
             },
         }
 
-        // TODO: is this needed?
-        // initialize_params.frameRateNum = params.frame_rate;
-
         params.apply_to_encode_config(&mut encode_config);
         Self::validate_encode_config(encode_config, params.codec, self.buffer_format)?;
 

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -19,7 +19,7 @@ use nv_video_codec_sys::{
     NV_ENC_PIC_PARAMS, NV_ENC_PRESET_CONFIG, NV_ENC_QP, NV_ENC_RECONFIGURE_PARAMS,
     NV_ENC_REGISTERED_PTR, NV_ENC_REGISTER_RESOURCE,
 };
-use std::{ffi::c_void, marker::PhantomData, ptr::null_mut};
+use std::{ffi::c_void, marker::PhantomData};
 
 pub(super) const fn nvenc_api_struct_version(version: u32) -> u32 {
     NVENCAPI_VERSION | ((version) << 16) | (0x7 << 28)
@@ -113,6 +113,7 @@ where
         let (mut initialize_params, mut encode_config) =
             self.create_initialize_params_and_config(params)?;
 
+        self.initialize_params = initialize_params;
         initialize_params.encodeConfig = &raw mut encode_config;
 
         unsafe {
@@ -123,10 +124,7 @@ where
             .into_nvenc_result()?;
         }
 
-        initialize_params.encodeConfig = null_mut();
-        self.initialize_params = initialize_params;
         self.encode_config = encode_config;
-
         self.encoder_initialized = true;
 
         // TODO(efyang): convert this to a usize

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -40,10 +40,6 @@ const NV_ENC_CREATE_MV_BUFFER_VER: u32 = nvenc_api_struct_version(1);
 const NV_ENC_MAP_INPUT_RESOURCE_VER: u32 = nvenc_api_struct_version(4);
 const NV_ENC_REGISTER_RESOURCE_VER: u32 = nvenc_api_struct_version(3);
 
-// We accept frame rate as float, but NVENC API expects uint32 numerator and denominator. We set
-// a constant denominator as a tradeoff between precision and representable range.
-const FRAME_RATE_DENOMINATOR: u32 = 1000;
-
 #[repr(C)]
 pub(super) struct EncoderHandle {
     _data: [u8; 0],
@@ -171,7 +167,8 @@ where
     pub fn set_bitrate_and_frame_rate(
         &mut self,
         bitrate: u32,
-        frame_rate: f64,
+        frame_rate_numerator: u32,
+        frame_rate_denominator: u32,
     ) -> NvEncoderResult<()> {
         let mut params = _NV_ENC_RECONFIGURE_PARAMS {
             version: NV_ENC_RECONFIGURE_PARAMS_VER,
@@ -181,12 +178,13 @@ where
         params.set_resetEncoder(1);
         params.set_forceIDR(1);
 
-        self.initialize_params.frameRateNum = (frame_rate * FRAME_RATE_DENOMINATOR as f64) as u32;
-        self.initialize_params.frameRateDen = FRAME_RATE_DENOMINATOR;
+        self.initialize_params.frameRateNum = frame_rate_numerator;
+        self.initialize_params.frameRateDen = frame_rate_denominator;
 
         self.encode_config.rcParams.averageBitRate = bitrate;
         self.encode_config.rcParams.maxBitRate = bitrate;
 
+        let frame_rate = frame_rate_numerator as f64 / frame_rate_denominator as f64;
         let frame_size_in_bits = bitrate / frame_rate as u32;
         self.encode_config.rcParams.vbvBufferSize = frame_size_in_bits;
         self.encode_config.rcParams.vbvInitialDelay = frame_size_in_bits;
@@ -353,8 +351,8 @@ where
             encodeHeight: self.height,
             darWidth: self.width,
             darHeight: self.height,
-            frameRateNum: (params.frame_rate * FRAME_RATE_DENOMINATOR as f64) as u32,
-            frameRateDen: FRAME_RATE_DENOMINATOR,
+            frameRateNum: params.frame_rate_numerator,
+            frameRateDen: params.frame_rate_denominator,
             enablePTD: 1,
             maxEncodeWidth: self.width,
             maxEncodeHeight: self.height,

--- a/nv-video-codec/src/encoder/nvencodercuda.rs
+++ b/nv-video-codec/src/encoder/nvencodercuda.rs
@@ -7,11 +7,15 @@ use crate::{
     encoder::nvencoder::{Device, Input, NvEncInputFrame, NvEncoderSettings},
 };
 use cuda_gl_interop::{CudaSliceMut, Size};
-use cudarc::driver::CudaContext;
-use nv_video_codec_sys::{cuMemAllocPitch_v2, cuMemFree_v2, CUdeviceptr, _NV_ENC_DEVICE_TYPE};
+use cudarc::driver::{
+    sys::{cuMemcpy2D_v2, CUdeviceptr, CUmemorytype_enum, CUDA_MEMCPY2D},
+    CudaContext,
+};
+use nv_video_codec_sys::{cuMemAllocPitch_v2, cuMemFree_v2, _NV_ENC_DEVICE_TYPE};
 use std::{
     ffi::c_void,
     ops::{Deref, DerefMut},
+    ptr::null_mut,
     sync::Arc,
 };
 
@@ -175,5 +179,43 @@ impl NvEncoderResourceManager for NvEncoderCudaResourceManager {
 
     fn release_input_buffers(encoder: &mut NvEncoder<Self>) -> NvEncoderResult<()> {
         encoder.release_cuda_resources()
+    }
+}
+
+pub fn upload_nv12_data_to_cuda_resource(
+    data: &[u8],
+    resource: CudaSliceMut<'_>,
+    width: u32,
+    height: u32,
+) {
+    // NV12 data layout:
+    // - 8-bit width x height luma plane
+    // - 2 8-bit width/2 x height/2 chroma planes (each chroma value is shared by a 2x2 pixel block)
+    //   - when the chroma planes are interleaved, this results in 1 8-bit width x height/2 plane
+    let width = width as usize;
+    let luma_height = height as usize;
+    let chroma_height = height as usize / 2;
+
+    let m = CUDA_MEMCPY2D {
+        srcMemoryType: CUmemorytype_enum::CU_MEMORYTYPE_HOST,
+        srcHost: &raw const *data as *const c_void,
+        srcPitch: width,
+        dstMemoryType: CUmemorytype_enum::CU_MEMORYTYPE_DEVICE,
+        dstDevice: resource.buffer() as CUdeviceptr,
+        dstPitch: resource.pitch(),
+        WidthInBytes: width,
+        Height: luma_height + chroma_height,
+        srcXInBytes: 0,
+        srcY: 0,
+        srcDevice: 0,
+        srcArray: null_mut(),
+        dstXInBytes: 0,
+        dstY: 0,
+        dstHost: null_mut(),
+        dstArray: null_mut(),
+    };
+
+    unsafe {
+        cuMemcpy2D_v2(&raw const m);
     }
 }

--- a/nv-video-codec/src/encoder/nvencodercuda.rs
+++ b/nv-video-codec/src/encoder/nvencodercuda.rs
@@ -101,6 +101,7 @@ pub struct NvEncoderCudaResourceManager {}
 
 impl NvEncoderResourceManager for NvEncoderCudaResourceManager {
     type InputResource = CUdeviceptr;
+    // TODO(mbernat): Use a different type here, this one is only valid for `BufferFormat::ABGR`.
     type InputResourceRef<'a> = CudaSliceMut<'a>;
     type ResourceContext = Arc<CudaContext>;
 

--- a/nv-video-codec/src/encoder/nvencodercuda.rs
+++ b/nv-video-codec/src/encoder/nvencodercuda.rs
@@ -195,7 +195,7 @@ pub fn upload_nv12_data_to_cuda_resource(
     //   - when the chroma planes are interleaved, this results in 1 8-bit width x height/2 plane
     let width = width as usize;
     let luma_height = height as usize;
-    let chroma_height = height as usize / 2;
+    let chroma_height = (height as usize + 1) / 2;
 
     let m = CUDA_MEMCPY2D {
         srcMemoryType: CUmemorytype_enum::CU_MEMORYTYPE_HOST,

--- a/nv-video-codec/src/encoder/nvencodercuda.rs
+++ b/nv-video-codec/src/encoder/nvencodercuda.rs
@@ -202,7 +202,7 @@ pub fn upload_nv12_data_to_cuda_resource(
         srcHost: data.as_ptr() as *const c_void,
         srcPitch: width,
         dstMemoryType: CUmemorytype_enum::CU_MEMORYTYPE_DEVICE,
-        dstDevice: resource.buffer() as CUdeviceptr,
+        dstDevice: resource.as_mut_ptr() as CUdeviceptr,
         dstPitch: resource.pitch(),
         WidthInBytes: width,
         Height: luma_height + chroma_height,

--- a/nv-video-codec/src/encoder/nvencodercuda.rs
+++ b/nv-video-codec/src/encoder/nvencodercuda.rs
@@ -195,7 +195,7 @@ pub fn upload_nv12_data_to_cuda_resource(
     //   - when the chroma planes are interleaved, this results in 1 8-bit width x height/2 plane
     let width = width as usize;
     let luma_height = height as usize;
-    let chroma_height = (height as usize + 1) / 2;
+    let chroma_height = height.div_ceil(2) as usize;
 
     let m = CUDA_MEMCPY2D {
         srcMemoryType: CUmemorytype_enum::CU_MEMORYTYPE_HOST,

--- a/nv-video-codec/src/encoder/nvencodercuda.rs
+++ b/nv-video-codec/src/encoder/nvencodercuda.rs
@@ -199,7 +199,7 @@ pub fn upload_nv12_data_to_cuda_resource(
 
     let m = CUDA_MEMCPY2D {
         srcMemoryType: CUmemorytype_enum::CU_MEMORYTYPE_HOST,
-        srcHost: &raw const *data as *const c_void,
+        srcHost: data.as_ptr() as *const c_void,
         srcPitch: width,
         dstMemoryType: CUmemorytype_enum::CU_MEMORYTYPE_DEVICE,
         dstDevice: resource.buffer() as CUdeviceptr,

--- a/nv-video-codec/src/encoder/nvencodergl.rs
+++ b/nv-video-codec/src/encoder/nvencodergl.rs
@@ -171,7 +171,7 @@ pub fn upload_nv12_data_to_texture_resource(
     //   - when the chroma planes are interleaved, this results in 1 8-bit width x height/2 plane
     let width = width as i32;
     let luma_height = height as i32;
-    let chroma_height = (height as i32 + 1) / 2;
+    let chroma_height = height.div_ceil(2) as i32;
 
     unsafe {
         gl::BindTexture(resource.target, resource.texture);

--- a/nv-video-codec/src/encoder/nvencodergl.rs
+++ b/nv-video-codec/src/encoder/nvencodergl.rs
@@ -171,7 +171,7 @@ pub fn upload_nv12_data_to_texture_resource(
     //   - when the chroma planes are interleaved, this results in 1 8-bit width x height/2 plane
     let width = width as i32;
     let luma_height = height as i32;
-    let chroma_height = height as i32 / 2;
+    let chroma_height = (height as i32 + 1) / 2;
 
     unsafe {
         gl::BindTexture(resource.target, resource.texture);

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -182,12 +182,12 @@ pub struct EncodeRateControl {
     pub multi_pass: EncodeMultiPass,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
 pub struct NvEncoderParams {
     pub codec: EncodeCodec,
     pub preset: EncodePreset,
     pub tuning_info: EncodeTuningInfo,
-    pub frame_rate: u32,
+    pub frame_rate: f64,
     pub repeat_spspps: bool,
     pub rate_control: EncodeRateControl,
 }

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -187,7 +187,8 @@ pub struct NvEncoderParams {
     pub codec: EncodeCodec,
     pub preset: EncodePreset,
     pub tuning_info: EncodeTuningInfo,
-    pub frame_rate: f64,
+    pub frame_rate_numerator: u32,
+    pub frame_rate_denominator: u32,
     pub repeat_spspps: bool,
     pub rate_control: EncodeRateControl,
 }

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -48,7 +48,7 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
         // ULTRA_LOW might be like 0.5ms faster at times?
         // needs testing on dev installation
         tuning_info: EncodeTuningInfo::UltraLowLatency,
-        frame_rate: 60,
+        frame_rate: 60.0,
         // required for use with ffmpeg, not with nvcodec
         repeat_spspps: true,
         rate_control: EncodeRateControl {
@@ -86,6 +86,8 @@ fn encode_single_frame_grayscale() -> Result<()> {
     let (width, height) = (1280, 720);
     let mut encoder = util_init_encoder(width, height, BufferFormat::NV12)?;
     util_create_encoder(&mut encoder)?;
+
+    encoder.set_bitrate_and_frame_rate(10_000_000, 30.0)?;
 
     let data = include_bytes!("../resources/test/decode_out_grayscale.nv12");
     assert_eq!(data.len(), encoder.get_frame_size()? as usize);

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -7,9 +7,10 @@ use anyhow::Result;
 use cudarc::driver::{sys::CUctx_flags, CudaContext};
 use nv_video_codec::{
     encoder::{
-        nvencodercuda::NvEncoderCuda, types::BufferFormat, EncodeMultiPass, EncodePicFlags,
-        EncodeRateControl, EncodeRateControlMode, EncodeTuningInfo, NvEncoderParams,
-        NvEncoderSettings,
+        nvencodercuda::{upload_nv12_data_to_cuda_resource, NvEncoderCuda},
+        types::BufferFormat,
+        EncodeMultiPass, EncodePicFlags, EncodeRateControl, EncodeRateControlMode,
+        EncodeTuningInfo, NvEncoderParams, NvEncoderSettings,
     },
     guids::{EncodeCodec, EncodePreset},
 };
@@ -54,7 +55,7 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
         rate_control: EncodeRateControl {
             mode: EncodeRateControlMode::ConstantBitrate,
             low_delay_key_frame_scale: 1,
-            bit_rate: 13_000_000,
+            bit_rate: 16_000_000,
             enable_aq: true,
             multi_pass: EncodeMultiPass::TwoPassFullResolution,
             ..Default::default()
@@ -125,20 +126,28 @@ fn encode_multi_frame_3k() -> Result<()> {
     #[cfg(feature = "torture")]
     const NUM_TORTURE_FRAMES: usize = 500;
     #[cfg(not(feature = "torture"))]
-    const NUM_TORTURE_FRAMES: usize = 5;
+    const NUM_TORTURE_FRAMES: usize = 20;
 
     let mut total_time = Duration::from_millis(0);
     let mut blocked_time = Duration::from_millis(0);
     let mut frames_encoded = 0;
-    for _ in 0..NUM_TORTURE_FRAMES {
+    for i in 1..NUM_TORTURE_FRAMES {
         let start_time = Instant::now();
 
-        let _resource = encoder.get_next_input_resource();
-        // TODO: Copy data to resource
+        if i.is_multiple_of(5) {
+            encoder.set_bitrate_and_frame_rate(i as u32 * 1_000_000, 60.0)?;
+        }
+
+        let resource = encoder.get_next_input_resource();
+        upload_nv12_data_to_cuda_resource(data, resource, width, height);
 
         // force intra-frame and force per-frame metadata
         let pic_flags = EncodePicFlags::FORCE_IDR | EncodePicFlags::SEQUENCE_HEADER;
         encoder.encode_frame(&mut packet, pic_flags)?;
+
+        if !packet.is_empty() {
+            log::info!("packet.len() = {}, packet[0].len() = {}", packet.len(), packet[0].len());
+        }
 
         frames_encoded += 1;
         total_time += start_time.elapsed();

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -47,7 +47,7 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
         // ULTRA_LOW might be like 0.5ms faster at times?
         // needs testing on dev installation
         tuning_info: EncodeTuningInfo::UltraLowLatency,
-        frame_rate: 60,
+        frame_rate: 60.0,
         // required for use with ffmpeg, not with nvcodec
         repeat_spspps: true,
         rate_control: EncodeRateControl {
@@ -85,6 +85,8 @@ fn encode_single_frame_grayscale() -> Result<()> {
     let (width, height) = (1280, 720);
     let mut encoder = util_init_encoder(width, height, BufferFormat::NV12)?;
     util_create_encoder(&mut encoder)?;
+
+    encoder.set_bitrate_and_frame_rate(10_000_000, 30.0)?;
 
     let data = include_bytes!("../resources/test/decode_out_grayscale.nv12");
     assert_eq!(data.len(), encoder.get_frame_size()? as usize);

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -48,7 +48,8 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
         // ULTRA_LOW might be like 0.5ms faster at times?
         // needs testing on dev installation
         tuning_info: EncodeTuningInfo::UltraLowLatency,
-        frame_rate: 60.0,
+        frame_rate_numerator: 60,
+        frame_rate_denominator: 1,
         // required for use with ffmpeg, not with nvcodec
         repeat_spspps: true,
         rate_control: EncodeRateControl {
@@ -87,7 +88,7 @@ fn encode_single_frame_grayscale() -> Result<()> {
     let mut encoder = util_init_encoder(width, height, BufferFormat::NV12)?;
     util_create_encoder(&mut encoder)?;
 
-    encoder.set_bitrate_and_frame_rate(10_000_000, 30.0)?;
+    encoder.set_bitrate_and_frame_rate(10_000_000, 30, 1)?;
 
     let data = include_bytes!("../resources/test/decode_out_grayscale.nv12");
     assert_eq!(data.len(), encoder.get_frame_size()? as usize);
@@ -136,7 +137,7 @@ fn encode_multi_frame_3k() -> Result<()> {
         if i.is_multiple_of(5) {
             // Test encoding with progressively increasing bitrate.
             let bitrate = MAX_BITRATE / NUM_FRAMES_TO_ENCODE as u32 * (i as u32 + 1);
-            encoder.set_bitrate_and_frame_rate(bitrate, 60.0)?;
+            encoder.set_bitrate_and_frame_rate(bitrate, 60, 1)?;
         }
 
         let resource = encoder.get_next_input_resource();

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -118,9 +118,11 @@ fn encode_multi_frame_3k() -> Result<()> {
     let mut packet = Vec::new();
 
     #[cfg(feature = "torture")]
-    const NUM_TORTURE_FRAMES: usize = 500;
+    const NUM_FRAMES_TO_ENCODE: usize = 500;
     #[cfg(not(feature = "torture"))]
-    const NUM_TORTURE_FRAMES: usize = 20;
+    const NUM_FRAMES_TO_ENCODE: usize = 20;
+
+    const MAX_BITRATE: u32 = 50_000_000;
 
     let mut total_time = Duration::from_millis(0);
     let mut blocked_time = Duration::from_millis(0);
@@ -128,11 +130,13 @@ fn encode_multi_frame_3k() -> Result<()> {
 
     let mut force_i_frame = true;
 
-    for i in 0..NUM_TORTURE_FRAMES {
+    for i in 0..NUM_FRAMES_TO_ENCODE {
         let start_time = Instant::now();
 
         if i.is_multiple_of(5) {
-            encoder.set_bitrate_and_frame_rate(i as u32 * 1_000_000, 60.0)?;
+            // Test encoding with progressively increasing bitrate.
+            let bitrate = MAX_BITRATE / NUM_FRAMES_TO_ENCODE as u32 * (i as u32 + 1);
+            encoder.set_bitrate_and_frame_rate(bitrate, 60.0)?;
         }
 
         let resource = encoder.get_next_input_resource();
@@ -171,9 +175,9 @@ fn encode_multi_frame_3k() -> Result<()> {
     info_ctx!(
         "encode_multi",
         "Encoded {} frames in {:?}, {:?} per frame",
-        NUM_TORTURE_FRAMES,
+        NUM_FRAMES_TO_ENCODE,
         total_time,
-        total_time / NUM_TORTURE_FRAMES as u32
+        total_time / NUM_FRAMES_TO_ENCODE as u32
     );
 
     encoder.end_encode(&mut packet)?;

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -7,9 +7,10 @@ use anyhow::Result;
 use cudarc::driver::{sys::CUctx_flags, CudaContext};
 use nv_video_codec::{
     encoder::{
-        nvencodercuda::NvEncoderCuda, types::BufferFormat, EncodeMultiPass, EncodePicFlags,
-        EncodeRateControl, EncodeRateControlMode, EncodeTuningInfo, NvEncoderParams,
-        NvEncoderSettings,
+        nvencodercuda::{upload_nv12_data_to_cuda_resource, NvEncoderCuda},
+        types::BufferFormat,
+        EncodeMultiPass, EncodePicFlags, EncodeRateControl, EncodeRateControlMode,
+        EncodeTuningInfo, NvEncoderParams, NvEncoderSettings,
     },
     guids::{EncodeCodec, EncodePreset},
 };
@@ -53,7 +54,7 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
         rate_control: EncodeRateControl {
             mode: EncodeRateControlMode::ConstantBitrate,
             low_delay_key_frame_scale: 1,
-            bit_rate: 13_000_000,
+            bit_rate: 16_000_000,
             enable_aq: true,
             multi_pass: EncodeMultiPass::TwoPassFullResolution,
             ..Default::default()
@@ -119,7 +120,7 @@ fn encode_multi_frame_3k() -> Result<()> {
     #[cfg(feature = "torture")]
     const NUM_TORTURE_FRAMES: usize = 500;
     #[cfg(not(feature = "torture"))]
-    const NUM_TORTURE_FRAMES: usize = 5;
+    const NUM_TORTURE_FRAMES: usize = 20;
 
     let mut total_time = Duration::from_millis(0);
     let mut blocked_time = Duration::from_millis(0);
@@ -127,11 +128,15 @@ fn encode_multi_frame_3k() -> Result<()> {
 
     let mut force_i_frame = true;
 
-    for _ in 0..NUM_TORTURE_FRAMES {
+    for i in 0..NUM_TORTURE_FRAMES {
         let start_time = Instant::now();
 
-        let _resource = encoder.get_next_input_resource();
-        // TODO: Copy data to resource
+        if i.is_multiple_of(5) {
+            encoder.set_bitrate_and_frame_rate(i as u32 * 1_000_000, 60.0)?;
+        }
+
+        let resource = encoder.get_next_input_resource();
+        upload_nv12_data_to_cuda_resource(data, resource, width, height);
 
         let pic_flags = if force_i_frame {
             // force intra-frame and per-frame metadata
@@ -144,6 +149,10 @@ fn encode_multi_frame_3k() -> Result<()> {
 
         if !packet.is_empty() {
             force_i_frame = false;
+        }
+
+        if !packet.is_empty() {
+            log::info!("packet.len() = {}, packet[0].len() = {}", packet.len(), packet[0].len());
         }
 
         frames_encoded += 1;

--- a/nv-video-codec/tests/decoder.rs
+++ b/nv-video-codec/tests/decoder.rs
@@ -149,9 +149,9 @@ fn run_torture_test<FA: FrameAllocator>(
     frame_rate: Option<f64>, // frames/sec
 ) -> Result<()> {
     #[cfg(feature = "torture")]
-    const NUM_TORTURE_FRAMES: i64 = 10000;
+    const NUM_FRAMES_TO_ENCODE: i64 = 1000;
     #[cfg(not(feature = "torture"))]
-    const NUM_TORTURE_FRAMES: i64 = 10;
+    const NUM_FRAMES_TO_ENCODE: i64 = 20;
 
     let _ = SimpleLogger::new().init();
     let context = init_cuda_ctx()?;
@@ -163,7 +163,7 @@ fn run_torture_test<FA: FrameAllocator>(
     let mut total_time = Duration::from_millis(0);
     let mut blocked_time = Duration::from_millis(0);
     let mut total_frames_decoded = 0;
-    for timestamp in 0..NUM_TORTURE_FRAMES {
+    for timestamp in 0..NUM_FRAMES_TO_ENCODE {
         if let Some(frame_rate) = frame_rate {
             std::thread::sleep(Duration::from_secs_f64(1.0 / frame_rate));
         }
@@ -208,8 +208,8 @@ fn run_torture_test<FA: FrameAllocator>(
         "frames decoded: {}, in {:?}, avg time/frame in past {} frames: {:?}",
         total_frames_decoded,
         total_time,
-        NUM_TORTURE_FRAMES,
-        total_time / NUM_TORTURE_FRAMES as u32,
+        NUM_FRAMES_TO_ENCODE,
+        total_time / NUM_FRAMES_TO_ENCODE as u32,
     );
 
     Ok(())

--- a/nv-video-codec/tests/gl_encoder.rs
+++ b/nv-video-codec/tests/gl_encoder.rs
@@ -57,7 +57,7 @@ fn util_create_encoder(encoder: &mut NvEncoderGL) -> Result<()> {
         // ULTRA_LOW might be like 0.5ms faster at times?
         // needs testing on dev installation
         tuning_info: EncodeTuningInfo::UltraLowLatency,
-        frame_rate: 60,
+        frame_rate: 60.0,
         // required for use with ffmpeg, not with nvcodec
         repeat_spspps: true,
         rate_control: EncodeRateControl {

--- a/nv-video-codec/tests/gl_encoder.rs
+++ b/nv-video-codec/tests/gl_encoder.rs
@@ -54,7 +54,7 @@ fn util_create_encoder(encoder: &mut NvEncoderGL) -> Result<()> {
         // ULTRA_LOW might be like 0.5ms faster at times?
         // needs testing on dev installation
         tuning_info: EncodeTuningInfo::UltraLowLatency,
-        frame_rate: 60,
+        frame_rate: 60.0,
         // required for use with ffmpeg, not with nvcodec
         repeat_spspps: true,
         rate_control: EncodeRateControl {

--- a/nv-video-codec/tests/gl_encoder.rs
+++ b/nv-video-codec/tests/gl_encoder.rs
@@ -54,7 +54,8 @@ fn util_create_encoder(encoder: &mut NvEncoderGL) -> Result<()> {
         // ULTRA_LOW might be like 0.5ms faster at times?
         // needs testing on dev installation
         tuning_info: EncodeTuningInfo::UltraLowLatency,
-        frame_rate: 60.0,
+        frame_rate_numerator: 60,
+        frame_rate_denominator: 60,
         // required for use with ffmpeg, not with nvcodec
         repeat_spspps: true,
         rate_control: EncodeRateControl {


### PR DESCRIPTION
- On top of #78 
- Another direct nvpipe port.
- A more principled API would accept many more params, just like when creating an encoder. But that would also require further creation refactoring, which I'd rather postpone.