### PR TITLE
Introduce nv-video-codec-config crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["nv-video-codec", "nv-video-codec-sys"]
+members = ["nv-video-codec", "nv-video-codec-config", "nv-video-codec-sys"]

--- a/nv-video-codec-config/Cargo.toml
+++ b/nv-video-codec-config/Cargo.toml
@@ -5,3 +5,6 @@ authors = ["Edward Yang <edward.yang6771@gmail.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+schemars = { version = "1", features = ["preserve_order"] }
+serde = { version = "1", features = ["derive"] }

--- a/nv-video-codec-config/Cargo.toml
+++ b/nv-video-codec-config/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-schemars = { version = "1", features = ["preserve_order"] }
+schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/nv-video-codec-config/Cargo.toml
+++ b/nv-video-codec-config/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nv-video-codec-config"
+version = "0.1.0"
+authors = ["Edward Yang <edward.yang6771@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nv-video-codec-config/src/lib.rs
+++ b/nv-video-codec-config/src/lib.rs
@@ -1,11 +1,18 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub enum EncodeCodec {
     H264,
     #[default]
     Hevc,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub enum EncodeProfile {
     #[default]
     AutoSelect,
@@ -20,7 +27,9 @@ pub enum EncodeProfile {
 /// ```
 ///
 /// https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/nvenc-video-encoder-api-prog-guide/index.html#multi-nvenc-split-frame-encoding-in-hevc-and-av1
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub enum EncodePreset {
     P1,
     #[default]
@@ -28,7 +37,9 @@ pub enum EncodePreset {
     P7,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub enum EncodeRateControlMode {
     #[default]
     ConstantQp,
@@ -36,7 +47,9 @@ pub enum EncodeRateControlMode {
     ConstantBitrate,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub enum EncodeMultiPass {
     #[default]
     Disabled,
@@ -45,7 +58,9 @@ pub enum EncodeMultiPass {
 }
 
 /// Tuning information of NVENC encoding (not applicable to H264 and HEVC MEOnly mode).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub enum EncodeTuningInfo {
     HighQuality,
     #[default]
@@ -54,7 +69,9 @@ pub enum EncodeTuningInfo {
     Lossless,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub struct EncodeRateControl {
     pub mode: EncodeRateControlMode,
     pub low_delay_key_frame_scale: u8,
@@ -65,7 +82,9 @@ pub struct EncodeRateControl {
     pub multi_pass: EncodeMultiPass,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub struct NvEncoderParams {
     pub codec: EncodeCodec,
     pub preset: EncodePreset,

--- a/nv-video-codec-config/src/lib.rs
+++ b/nv-video-codec-config/src/lib.rs
@@ -1,0 +1,77 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum EncodeCodec {
+    H264,
+    #[default]
+    Hevc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum EncodeProfile {
+    #[default]
+    AutoSelect,
+}
+
+/// ```ignore
+///                     Preset
+/// Tuning Info         P1 P2 P3 P4 P5 P6 P7
+/// High Quality        Y  Y  N  N  N  N  N
+/// Low Latency         Y  Y  Y  Y  N  N  N
+/// Ultra Low Latency   Y  Y  Y  Y  N  N  N
+/// ```
+///
+/// https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/nvenc-video-encoder-api-prog-guide/index.html#multi-nvenc-split-frame-encoding-in-hevc-and-av1
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum EncodePreset {
+    P1,
+    #[default]
+    P3,
+    P7,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum EncodeRateControlMode {
+    #[default]
+    ConstantQp,
+    VariableBitrate,
+    ConstantBitrate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum EncodeMultiPass {
+    #[default]
+    Disabled,
+    TwoPassQuarterResolution,
+    TwoPassFullResolution,
+}
+
+/// Tuning information of NVENC encoding (not applicable to H264 and HEVC MEOnly mode).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum EncodeTuningInfo {
+    HighQuality,
+    #[default]
+    LowLatency,
+    UltraLowLatency,
+    Lossless,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EncodeRateControl {
+    pub mode: EncodeRateControlMode,
+    pub low_delay_key_frame_scale: u8,
+    pub bit_rate: u32,
+    pub vbv_buffer_size_bits: u32,
+    pub vbv_buffer_initial_delay: u32,
+    pub enable_aq: bool,
+    pub multi_pass: EncodeMultiPass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
+pub struct NvEncoderParams {
+    pub codec: EncodeCodec,
+    pub preset: EncodePreset,
+    pub tuning_info: EncodeTuningInfo,
+    pub frame_rate_numerator: u32,
+    pub frame_rate_denominator: u32,
+    pub repeat_spspps: bool,
+    pub rate_control: EncodeRateControl,
+}

--- a/nv-video-codec/Cargo.toml
+++ b/nv-video-codec/Cargo.toml
@@ -14,6 +14,7 @@ bitflags = "1.2"
 cuda-gl-interop = { version = "0.1.0", git = "https://github.com/tonarino/cuda-gl-interop" }
 gl = "0.14"
 log = "0.4"
+nv-video-codec-config = { path = "../nv-video-codec-config" }
 nv-video-codec-sys = { path = "../nv-video-codec-sys" }
 parking_lot = "0.11"
 cudarc = { version = "0.19", features = ["cuda-version-from-build-system", "dynamic-linking"] }

--- a/nv-video-codec/src/encoder/defaults.rs
+++ b/nv-video-codec/src/encoder/defaults.rs
@@ -1,5 +1,5 @@
 use super::nvencoder::{NV_ENC_CONFIG_VER, NV_ENC_PRESET_CONFIG_VER};
-use crate::guids::EncodeProfile;
+use crate::guids::{EncodeProfile, IntoGuid as _};
 use nv_video_codec_sys::{
     _NV_ENC_MV_PRECISION, NV_ENC_CONFIG, NV_ENC_PARAMS_FRAME_FIELD_MODE, NV_ENC_PRESET_CONFIG,
 };
@@ -13,7 +13,7 @@ impl CustomDefault for NV_ENC_CONFIG {
         Self {
             version: NV_ENC_CONFIG_VER,
             frameFieldMode: NV_ENC_PARAMS_FRAME_FIELD_MODE::NV_ENC_PARAMS_FRAME_FIELD_MODE_FRAME,
-            profileGUID: EncodeProfile::AutoSelect.as_guid(),
+            profileGUID: EncodeProfile::AutoSelect.into_guid(),
             gopLength: Default::default(),
             frameIntervalP: Default::default(),
             monoChromeEncoding: Default::default(),

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     encoder::{
         apply_params_to_encode_config, defaults::CustomDefault, EncodePicFlags,
-        EncodeRateControlMode, FfiInto as _, NvEncoderParams,
+        EncodeRateControlMode, IntoFfi as _, NvEncoderParams,
     },
     guids::{EncodeCodec, IntoGuid as _},
 };
@@ -384,10 +384,10 @@ where
         let mut encode_config = preset_config.presetCfg;
         encode_config.frameIntervalP = 1;
         encode_config.gopLength = NVENC_INFINITE_GOPLENGTH;
-        encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.ffi_into();
+        encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into_ffi();
 
         if !self.motion_estimation_only {
-            initialize_params.tuningInfo = params.tuning_info.ffi_into();
+            initialize_params.tuningInfo = params.tuning_info.into_ffi();
             let mut preset_config = NV_ENC_PRESET_CONFIG {
                 version: NV_ENC_PRESET_CONFIG_VER,
                 presetCfg: NV_ENC_CONFIG { version: NV_ENC_CONFIG_VER, ..CustomDefault::default() },
@@ -398,7 +398,7 @@ where
                     self.encoder_handle as *mut _,
                     params.codec.into_guid(),
                     params.preset.into_guid(),
-                    params.tuning_info.ffi_into(),
+                    params.tuning_info.into_ffi(),
                     &mut preset_config,
                 )
                 .into_nvenc_result()?;
@@ -407,7 +407,7 @@ where
             }
         } else {
             encode_config.version = NV_ENC_CONFIG_VER;
-            encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.ffi_into();
+            encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into_ffi();
             encode_config.rcParams.constQP = NV_ENC_QP { qpInterP: 28, qpInterB: 31, qpIntra: 25 };
         }
 

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -5,8 +5,11 @@ use super::{
     NvEncoderError, NvEncoderResult,
 };
 use crate::{
-    encoder::{defaults::CustomDefault, EncodePicFlags, EncodeRateControlMode, NvEncoderParams},
-    guids::EncodeCodec,
+    encoder::{
+        apply_params_to_encode_config, defaults::CustomDefault, EncodePicFlags,
+        EncodeRateControlMode, FfiInto as _, NvEncoderParams,
+    },
+    guids::{EncodeCodec, IntoGuid as _},
 };
 use nv_video_codec_sys::{
     NvEncodeAPICreateInstance, NvEncodeAPIGetMaxSupportedVersion, _NV_ENC_PIC_STRUCT,
@@ -343,8 +346,8 @@ where
         // nvpipe doesn't even use this
         let mut initialize_params = NV_ENC_INITIALIZE_PARAMS {
             version: NV_ENC_INITIALIZE_PARAMS_VER, // TODO(efyang) actual const func for this
-            encodeGUID: params.codec.as_guid(),
-            presetGUID: params.preset.as_guid(),
+            encodeGUID: params.codec.into_guid(),
+            presetGUID: params.preset.into_guid(),
             encodeWidth: self.width,
             encodeHeight: self.height,
             darWidth: self.width,
@@ -371,8 +374,8 @@ where
                 .nvEncGetEncodePresetConfig
                 .expect("Invalid nvEncGetEncodePresetConfig ptr")(
                 self.encoder_handle as *mut _,
-                params.codec.as_guid(),
-                params.preset.as_guid(),
+                params.codec.into_guid(),
+                params.preset.into_guid(),
                 &mut preset_config,
             )
             .into_nvenc_result()?;
@@ -381,10 +384,10 @@ where
         let mut encode_config = preset_config.presetCfg;
         encode_config.frameIntervalP = 1;
         encode_config.gopLength = NVENC_INFINITE_GOPLENGTH;
-        encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into();
+        encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.ffi_into();
 
         if !self.motion_estimation_only {
-            initialize_params.tuningInfo = params.tuning_info.into();
+            initialize_params.tuningInfo = params.tuning_info.ffi_into();
             let mut preset_config = NV_ENC_PRESET_CONFIG {
                 version: NV_ENC_PRESET_CONFIG_VER,
                 presetCfg: NV_ENC_CONFIG { version: NV_ENC_CONFIG_VER, ..CustomDefault::default() },
@@ -393,9 +396,9 @@ where
             unsafe {
                 self.nv_encode_api_function_list.nvEncGetEncodePresetConfigEx.unwrap()(
                     self.encoder_handle as *mut _,
-                    params.codec.as_guid(),
-                    params.preset.as_guid(),
-                    params.tuning_info.into(),
+                    params.codec.into_guid(),
+                    params.preset.into_guid(),
+                    params.tuning_info.ffi_into(),
                     &mut preset_config,
                 )
                 .into_nvenc_result()?;
@@ -404,7 +407,7 @@ where
             }
         } else {
             encode_config.version = NV_ENC_CONFIG_VER;
-            encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.into();
+            encode_config.rcParams.rateControlMode = EncodeRateControlMode::ConstantQp.ffi_into();
             encode_config.rcParams.constQP = NV_ENC_QP { qpInterP: 28, qpInterB: 31, qpIntra: 25 };
         }
 
@@ -440,7 +443,7 @@ where
             },
         }
 
-        params.apply_to_encode_config(&mut encode_config);
+        apply_params_to_encode_config(params, &mut encode_config);
         Self::validate_encode_config(encode_config, params.codec, self.buffer_format)?;
 
         Ok((initialize_params, encode_config))

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -1,9 +1,13 @@
 use super::{NvEncError, NvEncoderError};
-use crate::guids::{EncodeCodec, EncodePreset};
+use crate::guids::EncodeCodec;
 use ffi::_NV_ENC_BUFFER_FORMAT;
 use nv_video_codec_sys::{
     self as ffi, NV_ENC_CONFIG, NV_ENC_MULTI_PASS, NV_ENC_PARAMS_RC_MODE, NV_ENC_PIC_FLAGS,
     NV_ENC_TUNING_INFO,
+};
+
+pub use nv_video_codec_config::{
+    EncodeMultiPass, EncodeRateControl, EncodeRateControlMode, EncodeTuningInfo, NvEncoderParams,
 };
 
 ffi_enum! {
@@ -108,16 +112,22 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum EncodeRateControlMode {
-    #[default]
-    ConstantQp,
-    VariableBitrate,
-    ConstantBitrate,
+pub(crate) trait FfiFrom<T> {
+    fn ffi_from(value: T) -> Self;
 }
 
-impl From<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
-    fn from(value: EncodeRateControlMode) -> Self {
+pub(crate) trait FfiInto<T> {
+    fn ffi_into(self) -> T;
+}
+
+impl<T, U: FfiFrom<T>> FfiInto<U> for T {
+    fn ffi_into(self) -> U {
+        U::ffi_from(self)
+    }
+}
+
+impl FfiFrom<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
+    fn ffi_from(value: EncodeRateControlMode) -> Self {
         use NV_ENC_PARAMS_RC_MODE as MODE;
 
         match value {
@@ -128,16 +138,8 @@ impl From<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum EncodeMultiPass {
-    #[default]
-    Disabled,
-    TwoPassQuarterResolution,
-    TwoPassFullResolution,
-}
-
-impl From<EncodeMultiPass> for NV_ENC_MULTI_PASS {
-    fn from(value: EncodeMultiPass) -> Self {
+impl FfiFrom<EncodeMultiPass> for NV_ENC_MULTI_PASS {
+    fn ffi_from(value: EncodeMultiPass) -> Self {
         use NV_ENC_MULTI_PASS as PASS;
 
         match value {
@@ -148,18 +150,8 @@ impl From<EncodeMultiPass> for NV_ENC_MULTI_PASS {
     }
 }
 
-/// Tuning information of NVENC encoding (not applicable to H264 and HEVC MEOnly mode).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum EncodeTuningInfo {
-    HighQuality,
-    #[default]
-    LowLatency,
-    UltraLowLatency,
-    Lossless,
-}
-
-impl From<EncodeTuningInfo> for NV_ENC_TUNING_INFO {
-    fn from(value: EncodeTuningInfo) -> Self {
+impl FfiFrom<EncodeTuningInfo> for NV_ENC_TUNING_INFO {
+    fn ffi_from(value: EncodeTuningInfo) -> Self {
         match value {
             EncodeTuningInfo::HighQuality => NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_HIGH_QUALITY,
             EncodeTuningInfo::LowLatency => NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_LOW_LATENCY,
@@ -171,56 +163,35 @@ impl From<EncodeTuningInfo> for NV_ENC_TUNING_INFO {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct EncodeRateControl {
-    pub mode: EncodeRateControlMode,
-    pub low_delay_key_frame_scale: u8,
-    pub bit_rate: u32,
-    pub vbv_buffer_size_bits: u32,
-    pub vbv_buffer_initial_delay: u32,
-    pub enable_aq: bool,
-    pub multi_pass: EncodeMultiPass,
-}
+pub(crate) fn apply_params_to_encode_config(
+    params: NvEncoderParams,
+    encode_config: &mut NV_ENC_CONFIG,
+) {
+    encode_config.rcParams.rateControlMode = params.rate_control.mode.ffi_into();
+    encode_config.rcParams.lowDelayKeyFrameScale = params.rate_control.low_delay_key_frame_scale;
+    encode_config.rcParams.averageBitRate = params.rate_control.bit_rate;
+    encode_config.rcParams.maxBitRate = params.rate_control.bit_rate;
+    encode_config.rcParams.vbvBufferSize = params.rate_control.vbv_buffer_size_bits;
+    encode_config.rcParams.vbvInitialDelay = params.rate_control.vbv_buffer_initial_delay;
+    encode_config.rcParams.set_enableAQ(params.rate_control.enable_aq as u32);
+    encode_config.rcParams.multiPass = params.rate_control.multi_pass.ffi_into();
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
-pub struct NvEncoderParams {
-    pub codec: EncodeCodec,
-    pub preset: EncodePreset,
-    pub tuning_info: EncodeTuningInfo,
-    pub frame_rate_numerator: u32,
-    pub frame_rate_denominator: u32,
-    pub repeat_spspps: bool,
-    pub rate_control: EncodeRateControl,
-}
-
-impl NvEncoderParams {
-    pub(crate) fn apply_to_encode_config(&self, encode_config: &mut NV_ENC_CONFIG) {
-        encode_config.rcParams.rateControlMode = self.rate_control.mode.into();
-        encode_config.rcParams.lowDelayKeyFrameScale = self.rate_control.low_delay_key_frame_scale;
-        encode_config.rcParams.averageBitRate = self.rate_control.bit_rate;
-        encode_config.rcParams.maxBitRate = self.rate_control.bit_rate;
-        encode_config.rcParams.vbvBufferSize = self.rate_control.vbv_buffer_size_bits;
-        encode_config.rcParams.vbvInitialDelay = self.rate_control.vbv_buffer_initial_delay;
-        encode_config.rcParams.set_enableAQ(self.rate_control.enable_aq as u32);
-        encode_config.rcParams.multiPass = self.rate_control.multi_pass.into();
-
-        match self.codec {
-            EncodeCodec::H264 =>
-            // SAFETY: We checked the codec is H264, so we can access the union field.
-            unsafe {
-                encode_config
-                    .encodeCodecConfig
-                    .h264Config
-                    .set_repeatSPSPPS(self.repeat_spspps as u32);
-            },
-            EncodeCodec::Hevc =>
-            // SAFETY: We checked the codec is HEVC, so we can access the union field.
-            unsafe {
-                encode_config
-                    .encodeCodecConfig
-                    .hevcConfig
-                    .set_repeatSPSPPS(self.repeat_spspps as u32);
-            },
-        }
+    match params.codec {
+        EncodeCodec::H264 =>
+        // SAFETY: We checked the codec is H264, so we can access the union field.
+        unsafe {
+            encode_config
+                .encodeCodecConfig
+                .h264Config
+                .set_repeatSPSPPS(params.repeat_spspps as u32);
+        },
+        EncodeCodec::Hevc =>
+        // SAFETY: We checked the codec is HEVC, so we can access the union field.
+        unsafe {
+            encode_config
+                .encodeCodecConfig
+                .hevcConfig
+                .set_repeatSPSPPS(params.repeat_spspps as u32);
+        },
     }
 }

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -112,22 +112,25 @@ bitflags! {
     }
 }
 
-pub(crate) trait FfiFrom<T> {
-    fn ffi_from(value: T) -> Self;
+/// This is the same as the standard [`From`] trait, which we cannot use because of the orphan rule.
+pub(crate) trait FromConfig<T> {
+    fn from_config(value: T) -> Self;
 }
 
-pub(crate) trait FfiInto<T> {
-    fn ffi_into(self) -> T;
+/// This is the same as the standard [`Into`] trait, which we cannot use because of the orphan rule.
+pub(crate) trait IntoFfi<T> {
+    fn into_ffi(self) -> T;
 }
 
-impl<T, U: FfiFrom<T>> FfiInto<U> for T {
-    fn ffi_into(self) -> U {
-        U::ffi_from(self)
+/// Implement Into for everything that implements From the other way.
+impl<T, U: FromConfig<T>> IntoFfi<U> for T {
+    fn into_ffi(self) -> U {
+        U::from_config(self)
     }
 }
 
-impl FfiFrom<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
-    fn ffi_from(value: EncodeRateControlMode) -> Self {
+impl FromConfig<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
+    fn from_config(value: EncodeRateControlMode) -> Self {
         use NV_ENC_PARAMS_RC_MODE as MODE;
 
         match value {
@@ -138,8 +141,8 @@ impl FfiFrom<EncodeRateControlMode> for NV_ENC_PARAMS_RC_MODE {
     }
 }
 
-impl FfiFrom<EncodeMultiPass> for NV_ENC_MULTI_PASS {
-    fn ffi_from(value: EncodeMultiPass) -> Self {
+impl FromConfig<EncodeMultiPass> for NV_ENC_MULTI_PASS {
+    fn from_config(value: EncodeMultiPass) -> Self {
         use NV_ENC_MULTI_PASS as PASS;
 
         match value {
@@ -150,8 +153,8 @@ impl FfiFrom<EncodeMultiPass> for NV_ENC_MULTI_PASS {
     }
 }
 
-impl FfiFrom<EncodeTuningInfo> for NV_ENC_TUNING_INFO {
-    fn ffi_from(value: EncodeTuningInfo) -> Self {
+impl FromConfig<EncodeTuningInfo> for NV_ENC_TUNING_INFO {
+    fn from_config(value: EncodeTuningInfo) -> Self {
         match value {
             EncodeTuningInfo::HighQuality => NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_HIGH_QUALITY,
             EncodeTuningInfo::LowLatency => NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_LOW_LATENCY,
@@ -167,14 +170,14 @@ pub(crate) fn apply_params_to_encode_config(
     params: NvEncoderParams,
     encode_config: &mut NV_ENC_CONFIG,
 ) {
-    encode_config.rcParams.rateControlMode = params.rate_control.mode.ffi_into();
+    encode_config.rcParams.rateControlMode = params.rate_control.mode.into_ffi();
     encode_config.rcParams.lowDelayKeyFrameScale = params.rate_control.low_delay_key_frame_scale;
     encode_config.rcParams.averageBitRate = params.rate_control.bit_rate;
     encode_config.rcParams.maxBitRate = params.rate_control.bit_rate;
     encode_config.rcParams.vbvBufferSize = params.rate_control.vbv_buffer_size_bits;
     encode_config.rcParams.vbvInitialDelay = params.rate_control.vbv_buffer_initial_delay;
     encode_config.rcParams.set_enableAQ(params.rate_control.enable_aq as u32);
-    encode_config.rcParams.multiPass = params.rate_control.multi_pass.ffi_into();
+    encode_config.rcParams.multiPass = params.rate_control.multi_pass.into_ffi();
 
     match params.codec {
         EncodeCodec::H264 =>

--- a/nv-video-codec/src/guids.rs
+++ b/nv-video-codec/src/guids.rs
@@ -6,16 +6,14 @@ use nv_video_codec_sys::{
     GUID,
 };
 
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum EncodeCodec {
-    H264,
-    #[default]
-    Hevc,
+pub use nv_video_codec_config::{EncodeCodec, EncodePreset, EncodeProfile};
+
+pub(crate) trait IntoGuid {
+    fn into_guid(self) -> GUID;
 }
 
-impl EncodeCodec {
-    pub(crate) fn as_guid(&self) -> GUID {
+impl IntoGuid for EncodeCodec {
+    fn into_guid(self) -> GUID {
         match self {
             EncodeCodec::H264 => NV_ENC_CODEC_H264_GUID,
             EncodeCodec::Hevc => NV_ENC_CODEC_HEVC_GUID,
@@ -23,41 +21,16 @@ impl EncodeCodec {
     }
 }
 
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum EncodeProfile {
-    #[default]
-    AutoSelect,
-}
-
-impl EncodeProfile {
-    pub(crate) fn as_guid(&self) -> GUID {
+impl IntoGuid for EncodeProfile {
+    fn into_guid(self) -> GUID {
         match self {
             EncodeProfile::AutoSelect => NV_ENC_CODEC_PROFILE_AUTOSELECT_GUID,
         }
     }
 }
 
-/// ```ignore
-///                     Preset
-/// Tuning Info         P1 P2 P3 P4 P5 P6 P7
-/// High Quality        Y  Y  N  N  N  N  N
-/// Low Latency         Y  Y  Y  Y  N  N  N
-/// Ultra Low Latency   Y  Y  Y  Y  N  N  N
-/// ```
-///
-/// https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/nvenc-video-encoder-api-prog-guide/index.html#multi-nvenc-split-frame-encoding-in-hevc-and-av1
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum EncodePreset {
-    P1,
-    #[default]
-    P3,
-    P7,
-}
-
-impl EncodePreset {
-    pub(crate) fn as_guid(&self) -> GUID {
+impl IntoGuid for EncodePreset {
+    fn into_guid(self) -> GUID {
         match self {
             EncodePreset::P1 => NV_ENC_PRESET_P1_GUID,
             EncodePreset::P3 => NV_ENC_PRESET_P3_GUID,

--- a/nv-video-codec/tests/decoder.rs
+++ b/nv-video-codec/tests/decoder.rs
@@ -123,7 +123,7 @@ fn decode_h265_3k_p_frame_device() -> Result<()> {
     let data = include_bytes!("../resources/test/single_p_frame_3k.hevc");
     let (frame, intra_pic_flag) =
         run_basic_decode2(&mut decoder, "decode_h265_3k_p_frame_device, part 0", data, 3088, 2076)?;
-    assert_eq!(frame, vec![]);
+    assert!(frame.is_empty());
     assert!(!intra_pic_flag);
 
     let data = include_bytes!("../resources/test/single_i_frame_3k.hevc");


### PR DESCRIPTION
This was done to make it easier to expose encoder settings in the config tool without having to depend on the actual encoder (might be even necessary, since sys crates are not going to work on wasm).

Does not strictly need to be merged but perhaps it's still a worthwhile change on its own? We just might want to feature flag `serde` and `schemars` derives.