### PR TITLE
Support long-term reference frames

### DIFF
--- a/nv-video-codec-config/src/lib.rs
+++ b/nv-video-codec-config/src/lib.rs
@@ -114,7 +114,7 @@ pub struct EncodeRateControl {
     pub multi_pass: EncodeMultiPass,
 }
 
-/// Controls how LTR frames are marked.
+/// Controls how long-term reference (LTR) frames are marked.
 ///
 /// Per Picture (preferred) — client explicitly marks each LTR frame.
 /// Trust (may be deprecated) — encoder auto-marks the first `ltr_num_frames` frames after IDR.

--- a/nv-video-codec-config/src/lib.rs
+++ b/nv-video-codec-config/src/lib.rs
@@ -126,7 +126,6 @@ pub struct NvEncoderParams {
     pub repeat_spspps: bool,
     pub rate_control: EncodeRateControl,
     pub qp_map_mode: EncodeQpMapMode,
-    pub enable_ltr: bool,
     pub ltr_num_frames: u32,
     pub ltr_trust_mode: u32,
 }

--- a/nv-video-codec-config/src/lib.rs
+++ b/nv-video-codec-config/src/lib.rs
@@ -114,6 +114,19 @@ pub struct EncodeRateControl {
     pub multi_pass: EncodeMultiPass,
 }
 
+/// Controls how LTR frames are marked.
+///
+/// Per Picture (preferred) — client explicitly marks each LTR frame.
+/// Trust (may be deprecated) — encoder auto-marks the first `ltr_num_frames` frames after IDR.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+pub enum LtrTrustMode {
+    #[default]
+    PerPicture,
+    Trust,
+}
+
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
 )]
@@ -127,5 +140,5 @@ pub struct NvEncoderParams {
     pub rate_control: EncodeRateControl,
     pub qp_map_mode: EncodeQpMapMode,
     pub ltr_num_frames: u32,
-    pub ltr_trust_mode: u32,
+    pub ltr_trust_mode: LtrTrustMode,
 }

--- a/nv-video-codec-config/src/lib.rs
+++ b/nv-video-codec-config/src/lib.rs
@@ -126,4 +126,7 @@ pub struct NvEncoderParams {
     pub repeat_spspps: bool,
     pub rate_control: EncodeRateControl,
     pub qp_map_mode: EncodeQpMapMode,
+    pub enable_ltr: bool,
+    pub ltr_num_frames: u32,
+    pub ltr_trust_mode: u32,
 }

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -6,8 +6,8 @@ use super::{
 };
 use crate::{
     encoder::{
-        apply_params_to_encode_config, defaults::CustomDefault, EncodePicFlags,
-        EncodeRateControlMode, IntoFfi as _, NvEncoderParams,
+        apply_params_to_encode_config, defaults::CustomDefault, EncodeFrameFeatures,
+        EncodePicFlags, EncodeRateControlMode, IntoFfi as _, NvEncoderParams,
     },
     guids::{EncodeCodec, IntoGuid as _},
 };
@@ -232,13 +232,7 @@ where
         &mut self,
         packet: &mut Vec<&[u8]>,
         pic_flags: EncodePicFlags,
-        // Per-block quality values. See `EncodeQpMapMode` for interpretation.
-        // Flat `i8` array in raster order: one per 16×16 block (H.264) or 32×32 block (HEVC).
-        qp_delta_map: Option<&[i8]>,
-        // Long-term reference (LTR) frame index to mark this frame as LTR.
-        ltr_mark_frame_idx: Option<u32>,
-        // Bitmap of LTR frame indices to use as reference for this frame.
-        ltr_use_frame_bitmap: Option<u32>,
+        features: EncodeFrameFeatures<'_>,
         // Opaque identifier for this frame, stored as `inputTimeStamp` in the NVENC pic params.
         // Used by `invalidate_ref_frames` to identify which frame to drop on packet loss.
         timestamp: u64,
@@ -255,9 +249,7 @@ where
             self.mapped_input_buffers[buffer_index as usize],
             self.bitstream_output_buffer[buffer_index as usize],
             pic_flags,
-            qp_delta_map,
-            ltr_mark_frame_idx,
-            ltr_use_frame_bitmap,
+            features,
             timestamp,
         );
 
@@ -779,13 +771,7 @@ where
         input_buffer: NV_ENC_INPUT_PTR,
         output_buffer: NV_ENC_OUTPUT_PTR,
         pic_flags: EncodePicFlags,
-        // Per-block quality values. See `EncodeQpMapMode` for interpretation.
-        // Flat `i8` array in raster order: one per 16×16 block (H.264) or 32×32 block (HEVC).
-        qp_delta_map: Option<&[i8]>,
-        // Long-term reference (LTR) frame index to mark this frame as LTR.
-        ltr_mark_frame_idx: Option<u32>,
-        // Bitmap of LTR frame indices to use as reference for this frame.
-        ltr_use_frame_bitmap: Option<u32>,
+        features: EncodeFrameFeatures<'_>,
         timestamp: u64,
     ) -> NvEncoderResult<()> {
         let mut pic_params = NV_ENC_PIC_PARAMS {
@@ -803,31 +789,32 @@ where
                 as *mut _,
             encodePicFlags: pic_flags.bits(),
             inputTimeStamp: timestamp,
-            qpDeltaMap: qp_delta_map.map_or(std::ptr::null::<i8>(), |m| m.as_ptr()) as *mut _,
-            qpDeltaMapSize: qp_delta_map.map_or(0, |m| m.len() as u32),
+            qpDeltaMap: features.qp_delta_map.map_or(std::ptr::null::<i8>(), |m| m.as_ptr())
+                as *mut _,
+            qpDeltaMapSize: features.qp_delta_map.map_or(0, |m| m.len() as u32),
             ..Default::default()
         };
 
-        if ltr_mark_frame_idx.is_some() || ltr_use_frame_bitmap.is_some() {
+        if features.ltr_mark_frame_idx.is_some() || features.ltr_use_frame_bitmap.is_some() {
             match self.initialize_params.encodeGUID {
                 g if g == NV_ENC_CODEC_H264_GUID => unsafe {
                     let h264 = &mut pic_params.codecPicParams.h264PicParams;
-                    if let Some(idx) = ltr_mark_frame_idx {
+                    if let Some(idx) = features.ltr_mark_frame_idx {
                         h264.set_ltrMarkFrame(1);
                         h264.ltrMarkFrameIdx = idx;
                     }
-                    if let Some(bitmap) = ltr_use_frame_bitmap {
+                    if let Some(bitmap) = features.ltr_use_frame_bitmap {
                         h264.set_ltrUseFrames(1);
                         h264.ltrUseFrameBitmap = bitmap;
                     }
                 },
                 g if g == NV_ENC_CODEC_HEVC_GUID => unsafe {
                     let hevc = &mut pic_params.codecPicParams.hevcPicParams;
-                    if let Some(idx) = ltr_mark_frame_idx {
+                    if let Some(idx) = features.ltr_mark_frame_idx {
                         hevc.set_ltrMarkFrame(1);
                         hevc.ltrMarkFrameIdx = idx;
                     }
-                    if let Some(bitmap) = ltr_use_frame_bitmap {
+                    if let Some(bitmap) = features.ltr_use_frame_bitmap {
                         hevc.set_ltrUseFrames(1);
                         hevc.ltrUseFrameBitmap = bitmap;
                     }

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -239,6 +239,9 @@ where
         ltr_mark_frame_idx: Option<u32>,
         // Bitmap of LTR frame indices to use as reference for this frame.
         ltr_use_frame_bitmap: Option<u32>,
+        // Opaque identifier for this frame, stored as `inputTimeStamp` in the NVENC pic params.
+        // Used by `invalidate_ref_frames` to identify which frame to drop on packet loss.
+        timestamp: u64,
     ) -> NvEncoderResult<()> {
         packet.clear();
         if !self.is_hw_encoder_initialized() {
@@ -255,6 +258,7 @@ where
             qp_delta_map,
             ltr_mark_frame_idx,
             ltr_use_frame_bitmap,
+            timestamp,
         );
 
         match encode_status {
@@ -769,6 +773,7 @@ where
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn do_encode(
         &mut self,
         input_buffer: NV_ENC_INPUT_PTR,
@@ -781,6 +786,7 @@ where
         ltr_mark_frame_idx: Option<u32>,
         // Bitmap of LTR frame indices to use as reference for this frame.
         ltr_use_frame_bitmap: Option<u32>,
+        timestamp: u64,
     ) -> NvEncoderResult<()> {
         let mut pic_params = NV_ENC_PIC_PARAMS {
             version: NV_ENC_PIC_PARAMS_VER,
@@ -796,6 +802,7 @@ where
                 .get_completion_event((self.to_send as u32) % (self.encoder_buffer as u32))
                 as *mut _,
             encodePicFlags: pic_flags.bits(),
+            inputTimeStamp: timestamp,
             qpDeltaMap: qp_delta_map.map_or(std::ptr::null::<i8>(), |m| m.as_ptr()) as *mut _,
             qpDeltaMapSize: qp_delta_map.map_or(0, |m| m.len() as u32),
             ..Default::default()
@@ -926,7 +933,9 @@ where
 
     /// Invalidate a corrupted reference frame and any dependent frames in the prediction chain.
     ///
-    /// Typically called on sustained packet loss or decoder reinitialization.
+    /// `timestamp` must match the `timestamp` value passed to `encode_frame` for the frame
+    /// that was lost. Typically called on sustained packet loss or decoder reinitialization,
+    /// not for isolated dropped packets.
     pub fn invalidate_ref_frames(&mut self, timestamp: u64) -> NvEncoderResult<()> {
         if self.encoder_handle.is_null() {
             return Err(NvEncError::EncoderNotInitialized.into());

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -765,7 +765,6 @@ where
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn do_encode(
         &mut self,
         input_buffer: NV_ENC_INPUT_PTR,

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -805,7 +805,7 @@ where
                     }
                     if let Some(bitmap) = features.ltr_use_frame_bitmap {
                         h264.set_ltrUseFrames(1);
-                        h264.ltrUseFrameBitmap = bitmap;
+                        h264.ltrUseFrameBitmap = bitmap.0;
                     }
                 },
                 g if g == NV_ENC_CODEC_HEVC_GUID => unsafe {
@@ -816,7 +816,7 @@ where
                     }
                     if let Some(bitmap) = features.ltr_use_frame_bitmap {
                         hevc.set_ltrUseFrames(1);
-                        hevc.ltrUseFrameBitmap = bitmap;
+                        hevc.ltrUseFrameBitmap = bitmap.0;
                     }
                 },
                 _ => {},

--- a/nv-video-codec/src/encoder/nvencoder.rs
+++ b/nv-video-codec/src/encoder/nvencoder.rs
@@ -12,6 +12,7 @@ use crate::{
     guids::{EncodeCodec, IntoGuid as _},
 };
 use nv_video_codec_sys::{
+    guids::{NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID},
     NvEncodeAPICreateInstance, NvEncodeAPIGetMaxSupportedVersion, _NV_ENC_PIC_STRUCT,
     _NV_ENC_RECONFIGURE_PARAMS, GUID, NVENCAPI_MAJOR_VERSION, NVENCAPI_MINOR_VERSION,
     NVENCAPI_VERSION, NVENC_INFINITE_GOPLENGTH, NV_ENCODE_API_FUNCTION_LIST, NV_ENC_BUFFER_USAGE,
@@ -234,6 +235,10 @@ where
         // Per-block quality values. See `EncodeQpMapMode` for interpretation.
         // Flat `i8` array in raster order: one per 16×16 block (H.264) or 32×32 block (HEVC).
         qp_delta_map: Option<&[i8]>,
+        // Long-term reference (LTR) frame index to mark this frame as LTR.
+        ltr_mark_frame_idx: Option<u32>,
+        // Bitmap of LTR frame indices to use as reference for this frame.
+        ltr_use_frame_bitmap: Option<u32>,
     ) -> NvEncoderResult<()> {
         packet.clear();
         if !self.is_hw_encoder_initialized() {
@@ -248,6 +253,8 @@ where
             self.bitstream_output_buffer[buffer_index as usize],
             pic_flags,
             qp_delta_map,
+            ltr_mark_frame_idx,
+            ltr_use_frame_bitmap,
         );
 
         match encode_status {
@@ -770,6 +777,10 @@ where
         // Per-block quality values. See `EncodeQpMapMode` for interpretation.
         // Flat `i8` array in raster order: one per 16×16 block (H.264) or 32×32 block (HEVC).
         qp_delta_map: Option<&[i8]>,
+        // Long-term reference (LTR) frame index to mark this frame as LTR.
+        ltr_mark_frame_idx: Option<u32>,
+        // Bitmap of LTR frame indices to use as reference for this frame.
+        ltr_use_frame_bitmap: Option<u32>,
     ) -> NvEncoderResult<()> {
         let mut pic_params = NV_ENC_PIC_PARAMS {
             version: NV_ENC_PIC_PARAMS_VER,
@@ -789,6 +800,34 @@ where
             qpDeltaMapSize: qp_delta_map.map_or(0, |m| m.len() as u32),
             ..Default::default()
         };
+
+        if ltr_mark_frame_idx.is_some() || ltr_use_frame_bitmap.is_some() {
+            match self.initialize_params.encodeGUID {
+                g if g == NV_ENC_CODEC_H264_GUID => unsafe {
+                    let h264 = &mut pic_params.codecPicParams.h264PicParams;
+                    if let Some(idx) = ltr_mark_frame_idx {
+                        h264.set_ltrMarkFrame(1);
+                        h264.ltrMarkFrameIdx = idx;
+                    }
+                    if let Some(bitmap) = ltr_use_frame_bitmap {
+                        h264.set_ltrUseFrames(1);
+                        h264.ltrUseFrameBitmap = bitmap;
+                    }
+                },
+                g if g == NV_ENC_CODEC_HEVC_GUID => unsafe {
+                    let hevc = &mut pic_params.codecPicParams.hevcPicParams;
+                    if let Some(idx) = ltr_mark_frame_idx {
+                        hevc.set_ltrMarkFrame(1);
+                        hevc.ltrMarkFrameIdx = idx;
+                    }
+                    if let Some(bitmap) = ltr_use_frame_bitmap {
+                        hevc.set_ltrUseFrames(1);
+                        hevc.ltrUseFrameBitmap = bitmap;
+                    }
+                },
+                _ => {},
+            }
+        }
 
         unsafe {
             self.nv_encode_api_function_list.nvEncEncodePicture.unwrap()(
@@ -879,6 +918,23 @@ where
             self.nv_encode_api_function_list.nvEncEncodePicture.unwrap()(
                 self.encoder_handle as *mut _,
                 &mut pic_params,
+            )
+            .into_nvenc_result()?;
+        }
+        Ok(())
+    }
+
+    /// Invalidate a corrupted reference frame and any dependent frames in the prediction chain.
+    ///
+    /// Typically called on sustained packet loss or decoder reinitialization.
+    pub fn invalidate_ref_frames(&mut self, timestamp: u64) -> NvEncoderResult<()> {
+        if self.encoder_handle.is_null() {
+            return Err(NvEncError::EncoderNotInitialized.into());
+        }
+        unsafe {
+            self.nv_encode_api_function_list.nvEncInvalidateRefFrames.unwrap()(
+                self.encoder_handle as *mut _,
+                timestamp,
             )
             .into_nvenc_result()?;
         }

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -99,6 +99,13 @@ impl BufferFormat {
     }
 }
 
+/// Bitmap of LTR frame indices to use as reference for an encoded frame.
+pub type LtrUseFrames = u32;
+
+pub fn ltr_use_frames(indices: &[u32]) -> LtrUseFrames {
+    indices.iter().map(|&i| 1u32 << i).sum()
+}
+
 /// Per-frame optional features for [`NvEncoder::encode_frame`].
 #[derive(Debug, Default, Clone)]
 pub struct EncodeFrameFeatures<'a> {
@@ -108,7 +115,7 @@ pub struct EncodeFrameFeatures<'a> {
     /// LTR frame index to mark this frame as a long-term reference.
     pub ltr_mark_frame_idx: Option<u32>,
     /// Bitmap of LTR frame indices to use as reference for this frame.
-    pub ltr_use_frame_bitmap: Option<u32>,
+    pub ltr_use_frame_bitmap: Option<LtrUseFrames>,
 }
 
 bitflags! {

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -99,7 +99,10 @@ impl BufferFormat {
     }
 }
 
-/// Bitmap of LTR frame indices to use as reference for an encoded frame.
+/// Bitmap of long-term reference (LTR) frame indices to use as reference for an encoded frame.
+///
+/// The provided indices need to have been already established by `EncodeFrameFeatures::ltr_mark_frame_idx()` on a prior frame
+/// and must still be in the encoder's reference picture buffer (i.e. not overwritten by a later mark or evicted).
 #[derive(Debug, Clone)]
 pub struct LtrUseFrames(pub u32);
 

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -99,6 +99,18 @@ impl BufferFormat {
     }
 }
 
+/// Per-frame optional features for [`NvEncoder::encode_frame`].
+#[derive(Debug, Default, Clone)]
+pub struct EncodeFrameFeatures<'a> {
+    /// Per-block quality values. See [`EncodeQpMapMode`](nv_video_codec_config::EncodeQpMapMode).
+    /// Flat `i8` array in raster order: one per 16×16 block (H.264) or 32×32 block (HEVC).
+    pub qp_delta_map: Option<&'a [i8]>,
+    /// LTR frame index to mark this frame as a long-term reference.
+    pub ltr_mark_frame_idx: Option<u32>,
+    /// Bitmap of LTR frame indices to use as reference for this frame.
+    pub ltr_use_frame_bitmap: Option<u32>,
+}
+
 bitflags! {
     pub struct EncodePicFlags: u32 {
         /// Encode the current picture as an Intra picture.

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -8,7 +8,7 @@ use nv_video_codec_sys::{
 
 pub use nv_video_codec_config::{
     EncodeMultiPass, EncodeQpMapMode, EncodeRateControl, EncodeRateControlMode, EncodeTuningInfo,
-    NvEncoderParams,
+    LtrTrustMode, NvEncoderParams,
 };
 
 ffi_enum! {
@@ -201,8 +201,10 @@ pub(crate) fn apply_params_to_encode_config(
             if params.ltr_num_frames > 0 {
                 h264.set_enableLTR(1);
                 h264.ltrNumFrames = params.ltr_num_frames;
-                // 0 = Per Picture mode (preferred), 1 = Trust mode (discouraged)
-                h264.ltrTrustMode = params.ltr_trust_mode;
+                h264.ltrTrustMode = match params.ltr_trust_mode {
+                    LtrTrustMode::PerPicture => 0,
+                    LtrTrustMode::Trust => 1,
+                };
             }
         },
         // SAFETY: We checked the codec is HEVC, so we can access the union field.
@@ -212,8 +214,10 @@ pub(crate) fn apply_params_to_encode_config(
             if params.ltr_num_frames > 0 {
                 hevc.set_enableLTR(1);
                 hevc.ltrNumFrames = params.ltr_num_frames;
-                // 0 = Per Picture mode (preferred), 1 = Trust mode (discouraged)
-                hevc.ltrTrustMode = params.ltr_trust_mode;
+                hevc.ltrTrustMode = match params.ltr_trust_mode {
+                    LtrTrustMode::PerPicture => 0,
+                    LtrTrustMode::Trust => 1,
+                };
             }
         },
     }

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -195,20 +195,26 @@ pub(crate) fn apply_params_to_encode_config(
 
     match params.codec {
         EncodeCodec::H264 =>
-        // SAFETY: We checked the codec is H264, so we can access the union field.
         unsafe {
-            encode_config
-                .encodeCodecConfig
-                .h264Config
-                .set_repeatSPSPPS(params.repeat_spspps as u32);
+            let h264 = &mut encode_config.encodeCodecConfig.h264Config;
+            h264.set_repeatSPSPPS(params.repeat_spspps as u32);
+            if params.enable_ltr {
+                h264.set_enableLTR(1);
+                h264.ltrNumFrames = params.ltr_num_frames;
+                // 0 = Per Picture mode (preferred), 1 = Trust mode (discouraged)
+                h264.ltrTrustMode = params.ltr_trust_mode;
+            }
         },
         EncodeCodec::Hevc =>
-        // SAFETY: We checked the codec is HEVC, so we can access the union field.
         unsafe {
-            encode_config
-                .encodeCodecConfig
-                .hevcConfig
-                .set_repeatSPSPPS(params.repeat_spspps as u32);
+            let hevc = &mut encode_config.encodeCodecConfig.hevcConfig;
+            hevc.set_repeatSPSPPS(params.repeat_spspps as u32);
+            if params.enable_ltr {
+                hevc.set_enableLTR(1);
+                hevc.ltrNumFrames = params.ltr_num_frames;
+                // 0 = Per Picture mode (preferred), 1 = Trust mode (discouraged)
+                hevc.ltrTrustMode = params.ltr_trust_mode;
+            }
         },
     }
 }

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -198,7 +198,7 @@ pub(crate) fn apply_params_to_encode_config(
         unsafe {
             let h264 = &mut encode_config.encodeCodecConfig.h264Config;
             h264.set_repeatSPSPPS(params.repeat_spspps as u32);
-            if params.enable_ltr {
+            if params.ltr_num_frames > 0 {
                 h264.set_enableLTR(1);
                 h264.ltrNumFrames = params.ltr_num_frames;
                 // 0 = Per Picture mode (preferred), 1 = Trust mode (discouraged)
@@ -209,7 +209,7 @@ pub(crate) fn apply_params_to_encode_config(
         unsafe {
             let hevc = &mut encode_config.encodeCodecConfig.hevcConfig;
             hevc.set_repeatSPSPPS(params.repeat_spspps as u32);
-            if params.enable_ltr {
+            if params.ltr_num_frames > 0 {
                 hevc.set_enableLTR(1);
                 hevc.ltrNumFrames = params.ltr_num_frames;
                 // 0 = Per Picture mode (preferred), 1 = Trust mode (discouraged)

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -100,10 +100,13 @@ impl BufferFormat {
 }
 
 /// Bitmap of LTR frame indices to use as reference for an encoded frame.
-pub type LtrUseFrames = u32;
+#[derive(Debug, Clone)]
+pub struct LtrUseFrames(pub u32);
 
-pub fn ltr_use_frames(indices: &[u32]) -> LtrUseFrames {
-    indices.iter().map(|&i| 1u32 << i).sum()
+impl LtrUseFrames {
+    pub fn from_indices(indices: &[u32]) -> Self {
+        Self(indices.iter().map(|&i| 1u32 << i).sum())
+    }
 }
 
 /// Per-frame optional features for [`NvEncoder::encode_frame`].

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -194,8 +194,7 @@ pub(crate) fn apply_params_to_encode_config(
     encode_config.rcParams.qpMapMode = params.qp_map_mode.into_ffi();
 
     match params.codec {
-        EncodeCodec::H264 =>
-        unsafe {
+        EncodeCodec::H264 => unsafe {
             let h264 = &mut encode_config.encodeCodecConfig.h264Config;
             h264.set_repeatSPSPPS(params.repeat_spspps as u32);
             if params.ltr_num_frames > 0 {
@@ -205,8 +204,7 @@ pub(crate) fn apply_params_to_encode_config(
                 h264.ltrTrustMode = params.ltr_trust_mode;
             }
         },
-        EncodeCodec::Hevc =>
-        unsafe {
+        EncodeCodec::Hevc => unsafe {
             let hevc = &mut encode_config.encodeCodecConfig.hevcConfig;
             hevc.set_repeatSPSPPS(params.repeat_spspps as u32);
             if params.ltr_num_frames > 0 {

--- a/nv-video-codec/src/encoder/types.rs
+++ b/nv-video-codec/src/encoder/types.rs
@@ -194,6 +194,7 @@ pub(crate) fn apply_params_to_encode_config(
     encode_config.rcParams.qpMapMode = params.qp_map_mode.into_ffi();
 
     match params.codec {
+        // SAFETY: We checked the codec is H264, so we can access the union field.
         EncodeCodec::H264 => unsafe {
             let h264 = &mut encode_config.encodeCodecConfig.h264Config;
             h264.set_repeatSPSPPS(params.repeat_spspps as u32);
@@ -204,6 +205,7 @@ pub(crate) fn apply_params_to_encode_config(
                 h264.ltrTrustMode = params.ltr_trust_mode;
             }
         },
+        // SAFETY: We checked the codec is HEVC, so we can access the union field.
         EncodeCodec::Hevc => unsafe {
             let hevc = &mut encode_config.encodeCodecConfig.hevcConfig;
             hevc.set_repeatSPSPPS(params.repeat_spspps as u32);

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -314,7 +314,6 @@ fn encode_qp_map_delta_hevc_odd_resolution() -> Result<()> {
 
 fn util_create_encoder_ltr(
     encoder: &mut NvEncoderCuda,
-    enable_ltr: bool,
     ltr_num_frames: u32,
     ltr_trust_mode: u32,
 ) -> Result<()> {
@@ -334,7 +333,6 @@ fn util_create_encoder_ltr(
             ..Default::default()
         },
         qp_map_mode: EncodeQpMapMode::Disabled,
-        enable_ltr,
         ltr_num_frames,
         ltr_trust_mode,
     })?;
@@ -344,7 +342,7 @@ fn util_create_encoder_ltr(
 #[test]
 fn encode_ltr_round_trip() -> Result<()> {
     let mut encoder = util_init_encoder(1280, 720, BufferFormat::NV12)?;
-    util_create_encoder_ltr(&mut encoder, true, 4, 0)?;
+    util_create_encoder_ltr(&mut encoder, 4, 0)?;
 
     let data = include_bytes!("../resources/test/decode_out_grayscale.nv12");
     let (w, h) = (1280, 720);

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -378,6 +378,19 @@ fn encode_ltr_round_trip() -> Result<()> {
     // Verify invalidate_ref_frames doesn't error.
     encoder.invalidate_ref_frames(0)?;
 
+    // Verify unmarked / out-of-range LTR indices are silently ignored.
+    upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
+    encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        EncodeFrameFeatures {
+            ltr_use_frame_bitmap: Some(LtrUseFrames::from_indices(&[5, 3])),
+            ..Default::default()
+        },
+        6,
+    )?;
+    bitstream.extend(packet.iter().map(|p| p.to_vec()));
+
     encoder.end_encode(&mut packet)?;
     bitstream.extend(packet.iter().map(|p| p.to_vec()));
 

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -61,6 +61,7 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
             ..Default::default()
         },
         qp_map_mode: EncodeQpMapMode::Disabled,
+        ..Default::default()
     };
 
     encoder.create_encoder(params)?;
@@ -98,7 +99,7 @@ fn encode_single_frame_grayscale() -> Result<()> {
     // TODO: Copy data to resource
 
     let mut packet = Vec::new();
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None)?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, None)?;
     assert_eq!(packet.len(), 1);
 
     encoder.end_encode(&mut packet)?;
@@ -150,7 +151,7 @@ fn encode_multi_frame_3k() -> Result<()> {
         } else {
             EncodePicFlags::empty()
         };
-        encoder.encode_frame(&mut packet, pic_flags, None)?;
+        encoder.encode_frame(&mut packet, pic_flags, None, None, None)?;
         assert_eq!(packet.len(), 1);
 
         if !packet.is_empty() {
@@ -194,7 +195,7 @@ fn encode_qp_map_disabled() -> Result<()> {
     util_create_encoder(&mut encoder)?;
 
     let mut packet = Vec::new();
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&[0i8; 100]))?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&[0i8; 100]), None, None)?;
     assert_eq!(packet.len(), 1);
 
     Ok(())
@@ -221,6 +222,7 @@ fn util_create_encoder_with(
             ..Default::default()
         },
         qp_map_mode,
+        ..Default::default()
     })?;
     Ok(())
 }
@@ -233,21 +235,21 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
     let mut packet = Vec::new();
 
     // Correct size for 32×32 CTBs: ceil(1280/32) * ceil(720/32) = 920.
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 920]))?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 920]), None, None)?;
     assert_eq!(packet.len(), 1);
 
     // Non-zero deltas are accepted.
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![5i8; 920]))?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![5i8; 920]), None, None)?;
     assert_eq!(packet.len(), 1);
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![-5i8; 920]))?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![-5i8; 920]), None, None)?;
     assert_eq!(packet.len(), 1);
 
     // Wrong size is rejected (too small).
-    let result = encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 100]));
+    let result = encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 100]), None, None);
     assert!(result.is_err());
 
     // Wrong size assuming 64×64 CTBs: ceil(1280/64) * ceil(720/64) = 240.
-    let result = encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 240]));
+    let result = encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 240]), None, None);
     assert!(result.is_err());
 
     Ok(())
@@ -261,11 +263,11 @@ fn encode_qp_map_delta_hevc_odd_resolution() -> Result<()> {
     let mut packet = Vec::new();
 
     // ceil(200/32) * ceil(200/32) = 7 * 7 = 49.
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 49]))?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 49]), None, None)?;
     assert_eq!(packet.len(), 1);
 
     // Wrong size is still rejected.
-    let result = encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 16]));
+    let result = encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 16]), None, None);
     assert!(result.is_err());
 
     Ok(())

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -13,7 +13,7 @@ use nv_video_codec::{
         nvencodercuda::{upload_nv12_data_to_cuda_resource, NvEncoderCuda},
         types::BufferFormat,
         EncodeMultiPass, EncodePicFlags, EncodeQpMapMode, EncodeRateControl, EncodeRateControlMode,
-        EncodeTuningInfo, NvEncoderParams, NvEncoderSettings,
+        EncodeTuningInfo, LtrTrustMode, NvEncoderParams, NvEncoderSettings,
     },
     guids::{EncodeCodec, EncodePreset},
 };
@@ -41,8 +41,8 @@ fn util_init_encoder(width: u32, height: u32, format: BufferFormat) -> Result<Nv
     Ok(encoder)
 }
 
-fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
-    let params = NvEncoderParams {
+fn common_encoder_params() -> NvEncoderParams {
+    NvEncoderParams {
         codec: EncodeCodec::Hevc,
         // preset guid seems to have no real effect on the speed???
         // needs testing as well
@@ -63,12 +63,12 @@ fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
             multi_pass: EncodeMultiPass::TwoPassFullResolution,
             ..Default::default()
         },
-        qp_map_mode: EncodeQpMapMode::Disabled,
         ..Default::default()
-    };
+    }
+}
 
-    encoder.create_encoder(params)?;
-
+fn util_create_encoder(encoder: &mut NvEncoderCuda) -> Result<()> {
+    encoder.create_encoder(common_encoder_params())?;
     Ok(())
 }
 
@@ -209,24 +209,7 @@ fn util_create_encoder_with(
     codec: EncodeCodec,
     qp_map_mode: EncodeQpMapMode,
 ) -> Result<()> {
-    encoder.create_encoder(NvEncoderParams {
-        codec,
-        preset: EncodePreset::P3,
-        tuning_info: EncodeTuningInfo::UltraLowLatency,
-        frame_rate_numerator: 60,
-        frame_rate_denominator: 1,
-        repeat_spspps: true,
-        rate_control: EncodeRateControl {
-            mode: EncodeRateControlMode::ConstantBitrate,
-            low_delay_key_frame_scale: 1,
-            bit_rate: 16_000_000,
-            enable_aq: true,
-            multi_pass: EncodeMultiPass::TwoPassFullResolution,
-            ..Default::default()
-        },
-        qp_map_mode,
-        ..Default::default()
-    })?;
+    encoder.create_encoder(NvEncoderParams { codec, qp_map_mode, ..common_encoder_params() })?;
     Ok(())
 }
 
@@ -328,26 +311,12 @@ fn encode_qp_map_delta_hevc_odd_resolution() -> Result<()> {
 fn util_create_encoder_ltr(
     encoder: &mut NvEncoderCuda,
     ltr_num_frames: u32,
-    ltr_trust_mode: u32,
+    ltr_trust_mode: LtrTrustMode,
 ) -> Result<()> {
     encoder.create_encoder(NvEncoderParams {
-        codec: EncodeCodec::Hevc,
-        preset: EncodePreset::P3,
-        tuning_info: EncodeTuningInfo::UltraLowLatency,
-        frame_rate_numerator: 60,
-        frame_rate_denominator: 1,
-        repeat_spspps: true,
-        rate_control: EncodeRateControl {
-            mode: EncodeRateControlMode::ConstantBitrate,
-            low_delay_key_frame_scale: 1,
-            bit_rate: 16_000_000,
-            enable_aq: true,
-            multi_pass: EncodeMultiPass::TwoPassFullResolution,
-            ..Default::default()
-        },
-        qp_map_mode: EncodeQpMapMode::Disabled,
         ltr_num_frames,
         ltr_trust_mode,
+        ..common_encoder_params()
     })?;
     Ok(())
 }
@@ -355,7 +324,7 @@ fn util_create_encoder_ltr(
 #[test]
 fn encode_ltr_round_trip() -> Result<()> {
     let mut encoder = util_init_encoder(1280, 720, BufferFormat::NV12)?;
-    util_create_encoder_ltr(&mut encoder, 4, 0)?;
+    util_create_encoder_ltr(&mut encoder, 4, LtrTrustMode::PerPicture)?;
 
     let data = include_bytes!("../resources/test/decode_out_grayscale.nv12");
     let (w, h) = (1280, 720);

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -10,11 +10,11 @@ use nv_video_codec::{
         frame::host::HostFrameAllocator, types::Codec, DecoderPacketFlags, NvDecoderBuilder,
     },
     encoder::{
-        ltr_use_frames,
         nvencodercuda::{upload_nv12_data_to_cuda_resource, NvEncoderCuda},
         types::BufferFormat,
         EncodeFrameFeatures, EncodeMultiPass, EncodePicFlags, EncodeQpMapMode, EncodeRateControl,
-        EncodeRateControlMode, EncodeTuningInfo, LtrTrustMode, NvEncoderParams, NvEncoderSettings,
+        EncodeRateControlMode, EncodeTuningInfo, LtrTrustMode, LtrUseFrames, NvEncoderParams,
+        NvEncoderSettings,
     },
     guids::{EncodeCodec, EncodePreset},
 };
@@ -340,7 +340,7 @@ fn encode_ltr_round_trip() -> Result<()> {
             &mut packet,
             EncodePicFlags::empty(),
             EncodeFrameFeatures {
-                ltr_use_frame_bitmap: Some(ltr_use_frames(&[0])),
+                ltr_use_frame_bitmap: Some(LtrUseFrames::from_indices(&[0])),
                 ..Default::default()
             },
             ts,
@@ -355,7 +355,7 @@ fn encode_ltr_round_trip() -> Result<()> {
         EncodePicFlags::empty(),
         EncodeFrameFeatures {
             ltr_mark_frame_idx: Some(1),
-            ltr_use_frame_bitmap: Some(ltr_use_frames(&[0, 1])),
+            ltr_use_frame_bitmap: Some(LtrUseFrames::from_indices(&[0, 1])),
             ..Default::default()
         },
         4,
@@ -368,7 +368,7 @@ fn encode_ltr_round_trip() -> Result<()> {
         &mut packet,
         EncodePicFlags::empty(),
         EncodeFrameFeatures {
-            ltr_use_frame_bitmap: Some(ltr_use_frames(&[1])),
+            ltr_use_frame_bitmap: Some(LtrUseFrames::from_indices(&[1])),
             ..Default::default()
         },
         5,

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -6,6 +6,9 @@ extern crate simple_logger;
 use anyhow::Result;
 use cudarc::driver::{sys::CUctx_flags, CudaContext};
 use nv_video_codec::{
+    decoder::{
+        frame::host::HostFrameAllocator, types::Codec, DecoderPacketFlags, NvDecoderBuilder,
+    },
     encoder::{
         nvencodercuda::{upload_nv12_data_to_cuda_resource, NvEncoderCuda},
         types::BufferFormat,
@@ -235,21 +238,51 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
     let mut packet = Vec::new();
 
     // Correct size for 32×32 CTBs: ceil(1280/32) * ceil(720/32) = 920.
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 920]), None, None)?;
+    encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        Some(&vec![0i8; 920]),
+        None,
+        None,
+    )?;
     assert_eq!(packet.len(), 1);
 
     // Non-zero deltas are accepted.
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![5i8; 920]), None, None)?;
+    encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        Some(&vec![5i8; 920]),
+        None,
+        None,
+    )?;
     assert_eq!(packet.len(), 1);
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![-5i8; 920]), None, None)?;
+    encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        Some(&vec![-5i8; 920]),
+        None,
+        None,
+    )?;
     assert_eq!(packet.len(), 1);
 
     // Wrong size is rejected (too small).
-    let result = encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 100]), None, None);
+    let result = encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        Some(&vec![0i8; 100]),
+        None,
+        None,
+    );
     assert!(result.is_err());
 
     // Wrong size assuming 64×64 CTBs: ceil(1280/64) * ceil(720/64) = 240.
-    let result = encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 240]), None, None);
+    let result = encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        Some(&vec![0i8; 240]),
+        None,
+        None,
+    );
     assert!(result.is_err());
 
     Ok(())
@@ -267,8 +300,106 @@ fn encode_qp_map_delta_hevc_odd_resolution() -> Result<()> {
     assert_eq!(packet.len(), 1);
 
     // Wrong size is still rejected.
-    let result = encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 16]), None, None);
+    let result = encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        Some(&vec![0i8; 16]),
+        None,
+        None,
+    );
     assert!(result.is_err());
 
+    Ok(())
+}
+
+fn util_create_encoder_ltr(
+    encoder: &mut NvEncoderCuda,
+    enable_ltr: bool,
+    ltr_num_frames: u32,
+    ltr_trust_mode: u32,
+) -> Result<()> {
+    encoder.create_encoder(NvEncoderParams {
+        codec: EncodeCodec::Hevc,
+        preset: EncodePreset::P3,
+        tuning_info: EncodeTuningInfo::UltraLowLatency,
+        frame_rate_numerator: 60,
+        frame_rate_denominator: 1,
+        repeat_spspps: true,
+        rate_control: EncodeRateControl {
+            mode: EncodeRateControlMode::ConstantBitrate,
+            low_delay_key_frame_scale: 1,
+            bit_rate: 16_000_000,
+            enable_aq: true,
+            multi_pass: EncodeMultiPass::TwoPassFullResolution,
+            ..Default::default()
+        },
+        qp_map_mode: EncodeQpMapMode::Disabled,
+        enable_ltr,
+        ltr_num_frames,
+        ltr_trust_mode,
+    })?;
+    Ok(())
+}
+
+#[test]
+fn encode_ltr_round_trip() -> Result<()> {
+    let mut encoder = util_init_encoder(1280, 720, BufferFormat::NV12)?;
+    util_create_encoder_ltr(&mut encoder, true, 4, 0)?;
+
+    let data = include_bytes!("../resources/test/decode_out_grayscale.nv12");
+    let (w, h) = (1280, 720);
+    let mut packet = Vec::new();
+    let mut bitstream: Vec<Vec<u8>> = Vec::new();
+
+    // Frame 0: IDR + mark index 0 as LTR
+    upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
+    encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::FORCE_IDR | EncodePicFlags::SEQUENCE_HEADER,
+        None,
+        Some(0),
+        None,
+    )?;
+    bitstream.extend(packet.iter().map(|p| p.to_vec()));
+
+    // Frames 1-3: use index 0 as LTR
+    for _ in 0..3 {
+        upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
+        encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, Some(1))?;
+        bitstream.extend(packet.iter().map(|p| p.to_vec()));
+    }
+
+    // Frame 4: mark index 1 as LTR, use both LTR 0+1
+    upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, Some(1), Some(0b11))?;
+    bitstream.extend(packet.iter().map(|p| p.to_vec()));
+
+    // Frame 5: use index 1 as LTR
+    upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, Some(0b10))?;
+    bitstream.extend(packet.iter().map(|p| p.to_vec()));
+
+    encoder.end_encode(&mut packet)?;
+    bitstream.extend(packet.iter().map(|p| p.to_vec()));
+
+    // Decode the LTR-encoded bitstream.
+    let context = init_cuda_ctx()?;
+    let mut decoder = NvDecoderBuilder::new(context, Codec::HEVC)
+        .low_latency(true)
+        .build::<HostFrameAllocator>()?;
+
+    let mut decoded = 0;
+    for (i, frame_data) in bitstream.iter().enumerate() {
+        if frame_data.is_empty() {
+            continue;
+        }
+        let output = decoder.decode_one(frame_data, DecoderPacketFlags::empty(), i as i64)?;
+        if output.frames.is_some() {
+            decoded += 1;
+        }
+    }
+
+    // Check we decoded at least one frame.
+    assert!(decoded > 0, "no frames decoded from LTR bitstream");
     Ok(())
 }

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -10,6 +10,7 @@ use nv_video_codec::{
         frame::host::HostFrameAllocator, types::Codec, DecoderPacketFlags, NvDecoderBuilder,
     },
     encoder::{
+        ltr_use_frames,
         nvencodercuda::{upload_nv12_data_to_cuda_resource, NvEncoderCuda},
         types::BufferFormat,
         EncodeFrameFeatures, EncodeMultiPass, EncodePicFlags, EncodeQpMapMode, EncodeRateControl,
@@ -338,7 +339,10 @@ fn encode_ltr_round_trip() -> Result<()> {
         encoder.encode_frame(
             &mut packet,
             EncodePicFlags::empty(),
-            EncodeFrameFeatures { ltr_use_frame_bitmap: Some(1), ..Default::default() },
+            EncodeFrameFeatures {
+                ltr_use_frame_bitmap: Some(ltr_use_frames(&[0])),
+                ..Default::default()
+            },
             ts,
         )?;
         bitstream.extend(packet.iter().map(|p| p.to_vec()));
@@ -351,7 +355,7 @@ fn encode_ltr_round_trip() -> Result<()> {
         EncodePicFlags::empty(),
         EncodeFrameFeatures {
             ltr_mark_frame_idx: Some(1),
-            ltr_use_frame_bitmap: Some(0b11),
+            ltr_use_frame_bitmap: Some(ltr_use_frames(&[0, 1])),
             ..Default::default()
         },
         4,
@@ -363,7 +367,10 @@ fn encode_ltr_round_trip() -> Result<()> {
     encoder.encode_frame(
         &mut packet,
         EncodePicFlags::empty(),
-        EncodeFrameFeatures { ltr_use_frame_bitmap: Some(0b10), ..Default::default() },
+        EncodeFrameFeatures {
+            ltr_use_frame_bitmap: Some(ltr_use_frames(&[1])),
+            ..Default::default()
+        },
         5,
     )?;
     bitstream.extend(packet.iter().map(|p| p.to_vec()));

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -102,7 +102,7 @@ fn encode_single_frame_grayscale() -> Result<()> {
     // TODO: Copy data to resource
 
     let mut packet = Vec::new();
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, None)?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, None, 0)?;
     assert_eq!(packet.len(), 1);
 
     encoder.end_encode(&mut packet)?;
@@ -154,7 +154,7 @@ fn encode_multi_frame_3k() -> Result<()> {
         } else {
             EncodePicFlags::empty()
         };
-        encoder.encode_frame(&mut packet, pic_flags, None, None, None)?;
+        encoder.encode_frame(&mut packet, pic_flags, None, None, None, 0)?;
         assert_eq!(packet.len(), 1);
 
         if !packet.is_empty() {
@@ -198,7 +198,7 @@ fn encode_qp_map_disabled() -> Result<()> {
     util_create_encoder(&mut encoder)?;
 
     let mut packet = Vec::new();
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&[0i8; 100]), None, None)?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&[0i8; 100]), None, None, 0)?;
     assert_eq!(packet.len(), 1);
 
     Ok(())
@@ -244,6 +244,7 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
         Some(&vec![0i8; 920]),
         None,
         None,
+        0,
     )?;
     assert_eq!(packet.len(), 1);
 
@@ -254,6 +255,7 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
         Some(&vec![5i8; 920]),
         None,
         None,
+        0,
     )?;
     assert_eq!(packet.len(), 1);
     encoder.encode_frame(
@@ -262,6 +264,7 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
         Some(&vec![-5i8; 920]),
         None,
         None,
+        0,
     )?;
     assert_eq!(packet.len(), 1);
 
@@ -272,6 +275,7 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
         Some(&vec![0i8; 100]),
         None,
         None,
+        0,
     );
     assert!(result.is_err());
 
@@ -282,6 +286,7 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
         Some(&vec![0i8; 240]),
         None,
         None,
+        0,
     );
     assert!(result.is_err());
 
@@ -296,7 +301,14 @@ fn encode_qp_map_delta_hevc_odd_resolution() -> Result<()> {
     let mut packet = Vec::new();
 
     // ceil(200/32) * ceil(200/32) = 7 * 7 = 49.
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&vec![0i8; 49]), None, None)?;
+    encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        Some(&vec![0i8; 49]),
+        None,
+        None,
+        0,
+    )?;
     assert_eq!(packet.len(), 1);
 
     // Wrong size is still rejected.
@@ -306,6 +318,7 @@ fn encode_qp_map_delta_hevc_odd_resolution() -> Result<()> {
         Some(&vec![0i8; 16]),
         None,
         None,
+        0,
     );
     assert!(result.is_err());
 
@@ -357,25 +370,29 @@ fn encode_ltr_round_trip() -> Result<()> {
         None,
         Some(0),
         None,
+        0,
     )?;
     bitstream.extend(packet.iter().map(|p| p.to_vec()));
 
     // Frames 1-3: use index 0 as LTR
-    for _ in 0..3 {
+    for ts in 1..=3 {
         upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
-        encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, Some(1))?;
+        encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, Some(1), ts)?;
         bitstream.extend(packet.iter().map(|p| p.to_vec()));
     }
 
     // Frame 4: mark index 1 as LTR, use both LTR 0+1
     upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, Some(1), Some(0b11))?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, Some(1), Some(0b11), 4)?;
     bitstream.extend(packet.iter().map(|p| p.to_vec()));
 
     // Frame 5: use index 1 as LTR
     upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, Some(0b10))?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, Some(0b10), 5)?;
     bitstream.extend(packet.iter().map(|p| p.to_vec()));
+
+    // Verify invalidate_ref_frames doesn't error.
+    encoder.invalidate_ref_frames(0)?;
 
     encoder.end_encode(&mut packet)?;
     bitstream.extend(packet.iter().map(|p| p.to_vec()));

--- a/nv-video-codec/tests/cuda_encoder.rs
+++ b/nv-video-codec/tests/cuda_encoder.rs
@@ -12,8 +12,8 @@ use nv_video_codec::{
     encoder::{
         nvencodercuda::{upload_nv12_data_to_cuda_resource, NvEncoderCuda},
         types::BufferFormat,
-        EncodeMultiPass, EncodePicFlags, EncodeQpMapMode, EncodeRateControl, EncodeRateControlMode,
-        EncodeTuningInfo, LtrTrustMode, NvEncoderParams, NvEncoderSettings,
+        EncodeFrameFeatures, EncodeMultiPass, EncodePicFlags, EncodeQpMapMode, EncodeRateControl,
+        EncodeRateControlMode, EncodeTuningInfo, LtrTrustMode, NvEncoderParams, NvEncoderSettings,
     },
     guids::{EncodeCodec, EncodePreset},
 };
@@ -102,7 +102,7 @@ fn encode_single_frame_grayscale() -> Result<()> {
     // TODO: Copy data to resource
 
     let mut packet = Vec::new();
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, None, 0)?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Default::default(), 0)?;
     assert_eq!(packet.len(), 1);
 
     encoder.end_encode(&mut packet)?;
@@ -154,7 +154,7 @@ fn encode_multi_frame_3k() -> Result<()> {
         } else {
             EncodePicFlags::empty()
         };
-        encoder.encode_frame(&mut packet, pic_flags, None, None, None, 0)?;
+        encoder.encode_frame(&mut packet, pic_flags, Default::default(), 0)?;
         assert_eq!(packet.len(), 1);
 
         if !packet.is_empty() {
@@ -198,7 +198,12 @@ fn encode_qp_map_disabled() -> Result<()> {
     util_create_encoder(&mut encoder)?;
 
     let mut packet = Vec::new();
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Some(&[0i8; 100]), None, None, 0)?;
+    encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        EncodeFrameFeatures { qp_delta_map: Some(&[0i8; 100]), ..Default::default() },
+        0,
+    )?;
     assert_eq!(packet.len(), 1);
 
     Ok(())
@@ -224,9 +229,7 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
     encoder.encode_frame(
         &mut packet,
         EncodePicFlags::empty(),
-        Some(&vec![0i8; 920]),
-        None,
-        None,
+        EncodeFrameFeatures { qp_delta_map: Some(&vec![0i8; 920]), ..Default::default() },
         0,
     )?;
     assert_eq!(packet.len(), 1);
@@ -235,18 +238,14 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
     encoder.encode_frame(
         &mut packet,
         EncodePicFlags::empty(),
-        Some(&vec![5i8; 920]),
-        None,
-        None,
+        EncodeFrameFeatures { qp_delta_map: Some(&vec![5i8; 920]), ..Default::default() },
         0,
     )?;
     assert_eq!(packet.len(), 1);
     encoder.encode_frame(
         &mut packet,
         EncodePicFlags::empty(),
-        Some(&vec![-5i8; 920]),
-        None,
-        None,
+        EncodeFrameFeatures { qp_delta_map: Some(&vec![-5i8; 920]), ..Default::default() },
         0,
     )?;
     assert_eq!(packet.len(), 1);
@@ -255,9 +254,7 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
     let result = encoder.encode_frame(
         &mut packet,
         EncodePicFlags::empty(),
-        Some(&vec![0i8; 100]),
-        None,
-        None,
+        EncodeFrameFeatures { qp_delta_map: Some(&vec![0i8; 100]), ..Default::default() },
         0,
     );
     assert!(result.is_err());
@@ -266,9 +263,7 @@ fn encode_qp_map_delta_hevc() -> Result<()> {
     let result = encoder.encode_frame(
         &mut packet,
         EncodePicFlags::empty(),
-        Some(&vec![0i8; 240]),
-        None,
-        None,
+        EncodeFrameFeatures { qp_delta_map: Some(&vec![0i8; 240]), ..Default::default() },
         0,
     );
     assert!(result.is_err());
@@ -287,9 +282,7 @@ fn encode_qp_map_delta_hevc_odd_resolution() -> Result<()> {
     encoder.encode_frame(
         &mut packet,
         EncodePicFlags::empty(),
-        Some(&vec![0i8; 49]),
-        None,
-        None,
+        EncodeFrameFeatures { qp_delta_map: Some(&vec![0i8; 49]), ..Default::default() },
         0,
     )?;
     assert_eq!(packet.len(), 1);
@@ -298,9 +291,7 @@ fn encode_qp_map_delta_hevc_odd_resolution() -> Result<()> {
     let result = encoder.encode_frame(
         &mut packet,
         EncodePicFlags::empty(),
-        Some(&vec![0i8; 16]),
-        None,
-        None,
+        EncodeFrameFeatures { qp_delta_map: Some(&vec![0i8; 16]), ..Default::default() },
         0,
     );
     assert!(result.is_err());
@@ -336,9 +327,7 @@ fn encode_ltr_round_trip() -> Result<()> {
     encoder.encode_frame(
         &mut packet,
         EncodePicFlags::FORCE_IDR | EncodePicFlags::SEQUENCE_HEADER,
-        None,
-        Some(0),
-        None,
+        EncodeFrameFeatures { ltr_mark_frame_idx: Some(0), ..Default::default() },
         0,
     )?;
     bitstream.extend(packet.iter().map(|p| p.to_vec()));
@@ -346,18 +335,37 @@ fn encode_ltr_round_trip() -> Result<()> {
     // Frames 1-3: use index 0 as LTR
     for ts in 1..=3 {
         upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
-        encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, Some(1), ts)?;
+        encoder.encode_frame(
+            &mut packet,
+            EncodePicFlags::empty(),
+            EncodeFrameFeatures { ltr_use_frame_bitmap: Some(1), ..Default::default() },
+            ts,
+        )?;
         bitstream.extend(packet.iter().map(|p| p.to_vec()));
     }
 
     // Frame 4: mark index 1 as LTR, use both LTR 0+1
     upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, Some(1), Some(0b11), 4)?;
+    encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        EncodeFrameFeatures {
+            ltr_mark_frame_idx: Some(1),
+            ltr_use_frame_bitmap: Some(0b11),
+            ..Default::default()
+        },
+        4,
+    )?;
     bitstream.extend(packet.iter().map(|p| p.to_vec()));
 
     // Frame 5: use index 1 as LTR
     upload_nv12_data_to_cuda_resource(data, encoder.get_next_input_resource(), w, h);
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, Some(0b10), 5)?;
+    encoder.encode_frame(
+        &mut packet,
+        EncodePicFlags::empty(),
+        EncodeFrameFeatures { ltr_use_frame_bitmap: Some(0b10), ..Default::default() },
+        5,
+    )?;
     bitstream.extend(packet.iter().map(|p| p.to_vec()));
 
     // Verify invalidate_ref_frames doesn't error.

--- a/nv-video-codec/tests/gl_encoder.rs
+++ b/nv-video-codec/tests/gl_encoder.rs
@@ -7,9 +7,9 @@ use anyhow::Result;
 use glutin::{event_loop::EventLoop, platform::unix::EventLoopExtUnix, Context, PossiblyCurrent};
 use nv_video_codec::{
     encoder::{
-        types::BufferFormat, upload_nv12_data_to_texture_resource, EncodePicFlags, EncodeQpMapMode,
-        EncodeRateControl, EncodeRateControlMode, EncodeTuningInfo, NvEncoderGL, NvEncoderParams,
-        NvEncoderSettings,
+        types::BufferFormat, upload_nv12_data_to_texture_resource, EncodeFrameFeatures,
+        EncodePicFlags, EncodeQpMapMode, EncodeRateControl, EncodeRateControlMode,
+        EncodeTuningInfo, NvEncoderGL, NvEncoderParams, NvEncoderSettings,
     },
     guids::{EncodeCodec, EncodePreset},
 };
@@ -103,7 +103,7 @@ fn encode_single_frame_grayscale() -> Result<()> {
     upload_nv12_data_to_texture_resource(data, resource, width, height);
 
     let mut packet = Vec::new();
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, None, 0)?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), Default::default(), 0)?;
 
     encoder.end_encode(&mut packet)?;
     assert_eq!(0, packet.len());
@@ -138,7 +138,7 @@ fn encode_multi_frame_3k() -> Result<()> {
         let start_time = Instant::now();
         let resource = encoder.get_next_input_resource();
         upload_nv12_data_to_texture_resource(data, resource, width, height);
-        encoder.encode_frame(&mut packet, pic_flags, None, None, None, 0)?;
+        encoder.encode_frame(&mut packet, pic_flags, Default::default(), 0)?;
 
         frames_encoded += 1;
         total_time += start_time.elapsed();

--- a/nv-video-codec/tests/gl_encoder.rs
+++ b/nv-video-codec/tests/gl_encoder.rs
@@ -103,7 +103,7 @@ fn encode_single_frame_grayscale() -> Result<()> {
     upload_nv12_data_to_texture_resource(data, resource, width, height);
 
     let mut packet = Vec::new();
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, None)?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, None, 0)?;
 
     encoder.end_encode(&mut packet)?;
     assert_eq!(0, packet.len());
@@ -138,7 +138,7 @@ fn encode_multi_frame_3k() -> Result<()> {
         let start_time = Instant::now();
         let resource = encoder.get_next_input_resource();
         upload_nv12_data_to_texture_resource(data, resource, width, height);
-        encoder.encode_frame(&mut packet, pic_flags, None, None, None)?;
+        encoder.encode_frame(&mut packet, pic_flags, None, None, None, 0)?;
 
         frames_encoded += 1;
         total_time += start_time.elapsed();

--- a/nv-video-codec/tests/gl_encoder.rs
+++ b/nv-video-codec/tests/gl_encoder.rs
@@ -7,9 +7,9 @@ use anyhow::Result;
 use glutin::{event_loop::EventLoop, platform::unix::EventLoopExtUnix, Context, PossiblyCurrent};
 use nv_video_codec::{
     encoder::{
-        types::BufferFormat, upload_nv12_data_to_texture_resource, EncodeFrameFeatures,
-        EncodePicFlags, EncodeQpMapMode, EncodeRateControl, EncodeRateControlMode,
-        EncodeTuningInfo, NvEncoderGL, NvEncoderParams, NvEncoderSettings,
+        types::BufferFormat, upload_nv12_data_to_texture_resource, EncodePicFlags, EncodeQpMapMode,
+        EncodeRateControl, EncodeRateControlMode, EncodeTuningInfo, NvEncoderGL, NvEncoderParams,
+        NvEncoderSettings,
     },
     guids::{EncodeCodec, EncodePreset},
 };

--- a/nv-video-codec/tests/gl_encoder.rs
+++ b/nv-video-codec/tests/gl_encoder.rs
@@ -66,6 +66,7 @@ fn util_create_encoder(encoder: &mut NvEncoderGL) -> Result<()> {
             ..Default::default()
         },
         qp_map_mode: EncodeQpMapMode::Disabled,
+        ..Default::default()
     };
 
     encoder.create_encoder(params)?;
@@ -102,7 +103,7 @@ fn encode_single_frame_grayscale() -> Result<()> {
     upload_nv12_data_to_texture_resource(data, resource, width, height);
 
     let mut packet = Vec::new();
-    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None)?;
+    encoder.encode_frame(&mut packet, EncodePicFlags::empty(), None, None, None)?;
 
     encoder.end_encode(&mut packet)?;
     assert_eq!(0, packet.len());
@@ -137,7 +138,7 @@ fn encode_multi_frame_3k() -> Result<()> {
         let start_time = Instant::now();
         let resource = encoder.get_next_input_resource();
         upload_nv12_data_to_texture_resource(data, resource, width, height);
-        encoder.encode_frame(&mut packet, pic_flags, None)?;
+        encoder.encode_frame(&mut packet, pic_flags, None, None, None)?;
 
         frames_encoded += 1;
         total_time += start_time.elapsed();


### PR DESCRIPTION
This adds the ability to mark and use long term reference frames. More details on the feature can be found here:

https://docs.nvidia.com/video-technologies/video-codec-sdk/13.1/nvenc-video-encoder-api-prog-guide/index.html#long-term-reference-in-h-264-hevc-and-av1

This enables a sender to mark frames as long term references for better network resiliency. When there's packet loss, instead of having your peer ask you for a full key frame, we can instead send a partial recovery frame based on an older LTR frame and should be much smaller than a key frame.

Here's [a nice post](https://atscaleconference.com/enhancing-video-network-resiliency-with-ltr-and-rs-code/) I read that gives a more extensive picture (tho not Nvidia specific).

Some iterations of the test were LLM generated. It would be good to specifically review whether or not the test is sufficient. I guess we could get more complex and check that the reference frame actually Less bandwidth transfer during packet loss recovery.. The current test may be basic enough.